### PR TITLE
Fix association path when resolving input faults

### DIFF
--- a/power-supply/power_supply.cpp
+++ b/power-supply/power_supply.cpp
@@ -40,7 +40,7 @@ using namespace sdbusplus::org::open_power::Witherspoon::Fault::Error;
 using namespace sdbusplus::xyz::openbmc_project::Common::Device::Error;
 namespace version = sdbusplus::xyz::openbmc_project::Software::server;
 
-constexpr auto ASSOCIATION_IFACE = "org.openbmc.Association";
+constexpr auto ASSOCIATION_IFACE = "xyz.openbmc_project.Association";
 constexpr auto LOGGING_IFACE = "xyz.openbmc_project.Logging.Entry";
 constexpr auto INVENTORY_IFACE = "xyz.openbmc_project.Inventory.Item";
 constexpr auto POWER_IFACE = "org.openbmc.control.Power";


### PR DESCRIPTION
When the C++ object mapper replaced the original python one, it
changed the name of the association interface.  Update this code
to match that.

Tested:  Input faults can now be resolved.

Change-Id: Idd0f355de82cc2b18399a50c24f28b20c9e2902f
Signed-off-by: Matt Spinler <spinler@us.ibm.com>

This is has been merged in master