### PR TITLE
Power supply input faults resolution

### DIFF
--- a/power-supply/power_supply.cpp
+++ b/power-supply/power_supply.cpp
@@ -40,7 +40,7 @@ using namespace sdbusplus::org::open_power::Witherspoon::Fault::Error;
 using namespace sdbusplus::xyz::openbmc_project::Common::Device::Error;
 namespace version = sdbusplus::xyz::openbmc_project::Software::server;
 
-constexpr auto ASSOCIATION_IFACE = "org.openbmc.Association";
+constexpr auto ASSOCIATION_IFACE = "xyz.openbmc_project.Association";
 constexpr auto LOGGING_IFACE = "xyz.openbmc_project.Logging.Entry";
 constexpr auto INVENTORY_IFACE = "xyz.openbmc_project.Inventory.Item";
 constexpr auto POWER_IFACE = "org.openbmc.control.Power";


### PR DESCRIPTION
If the AC power is plugged in when the system is totally off,
psu-monitor doesn't get to resolve errors because it can not see their
states change from faulted to not faulted.

Tested:

Physically cut off power and reapplied it to check for any incorrect LED
indications for the power supply. Checked error logs to make sure input
power faults were resolved.

Signed-off-by: Aatir Manzur <aatrapps@gmail.com>
Change-Id: I893b67fabc9075fdd0ea3ae3a2912bc443cbadf8