### PR TITLE
Add CPLD class for Mihawk platform

### DIFF
--- a/elog-errors.hpp
+++ b/elog-errors.hpp
@@ -21,6 +21,46 @@ namespace Fault
 {
 namespace Error
 {
+struct MemoryPowerFault;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnErrorVio0PGOODFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
 struct PowerSequencerPGOODFault;
 } // namespace Error
 } // namespace Fault
@@ -41,7 +81,7 @@ namespace Fault
 {
 namespace Error
 {
-struct MemoryPowerFault;
+struct PowerOnErrorVdn0PGOODFail;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -51,22 +91,162 @@ struct MemoryPowerFault;
 
 namespace sdbusplus
 {
-namespace xyz
+namespace org
 {
-namespace openbmc_project
+namespace open_power
 {
-namespace Common
+namespace Witherspoon
 {
-namespace Callout
+namespace Fault
 {
 namespace Error
 {
-struct GPIO;
+struct PowerOnError240VaFaultCFail;
 } // namespace Error
-} // namespace Callout
-} // namespace Common
-} // namespace openbmc_project
-} // namespace xyz
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnErrorVcs1PGOODFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnErrorP1V8PGOODFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnErrorGPU0PGOODFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnErrorVtt1PGOODFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnErrorVdn1PGOODFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnError240VaFaultJFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnErrorPSU0PSU1PGOODFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
 } // namespace sdbusplus
 
 namespace sdbusplus
@@ -82,6 +262,66 @@ namespace Fault
 namespace Error
 {
 struct PowerOnFailure;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnErrorGPU1PGOODFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnError240VaFaultBFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct Shutdown;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -121,86 +361,6 @@ namespace Callout
 {
 namespace Error
 {
-struct IIC;
-} // namespace Error
-} // namespace Callout
-} // namespace Common
-} // namespace openbmc_project
-} // namespace xyz
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-struct GPUPowerFault;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-struct Shutdown;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace xyz
-{
-namespace openbmc_project
-{
-namespace Common
-{
-namespace Callout
-{
-namespace Error
-{
-struct Inventory;
-} // namespace Error
-} // namespace Callout
-} // namespace Common
-} // namespace openbmc_project
-} // namespace xyz
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace xyz
-{
-namespace openbmc_project
-{
-namespace Common
-{
-namespace Callout
-{
-namespace Error
-{
 struct Device;
 } // namespace Error
 } // namespace Callout
@@ -222,6 +382,306 @@ namespace Fault
 namespace Error
 {
 struct PowerSequencerFault;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnError240VaFaultAFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerSupplyTemperatureFault;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnError240VaFaultLFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PSUPresentError;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnErrorPSU0PGOODFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnErrorP2V5BPGOODFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnErrorVdd0PGOODFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerSupplyShouldBeOn;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace xyz
+{
+namespace openbmc_project
+{
+namespace Common
+{
+namespace Callout
+{
+namespace Error
+{
+struct GPIO;
+} // namespace Error
+} // namespace Callout
+} // namespace Common
+} // namespace openbmc_project
+} // namespace xyz
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnError240VaFaultKFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnErrorP2V5APGOODFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnError;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnErrorP1V1PGOODFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnError240VaFaultHFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnErrorVio1PGOODFail;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -281,7 +741,7 @@ namespace Fault
 {
 namespace Error
 {
-struct PowerSupplyFanFault;
+struct PowerOnError240VaFaultEFail;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -301,7 +761,27 @@ namespace Fault
 {
 namespace Error
 {
-struct PowerSequencerVoltageFault;
+struct PowerOnErrorPSU1PGOODFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnErrorP0V9PGOODFail;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -341,7 +821,7 @@ namespace Fault
 {
 namespace Error
 {
-struct PowerSupplyTemperatureFault;
+struct PowerOnError240VaFaultDFail;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -361,7 +841,307 @@ namespace Fault
 {
 namespace Error
 {
-struct PowerSupplyShouldBeOn;
+struct PowerOnErrorP1V5PGOODFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerSupplyFanFault;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnErrorVddr1PGOODFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnErrorCPLDRegisterFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnError240VaFaultGFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnErrorVcs0PGOODFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace xyz
+{
+namespace openbmc_project
+{
+namespace Common
+{
+namespace Callout
+{
+namespace Error
+{
+struct Inventory;
+} // namespace Error
+} // namespace Callout
+} // namespace Common
+} // namespace openbmc_project
+} // namespace xyz
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace xyz
+{
+namespace openbmc_project
+{
+namespace Common
+{
+namespace Callout
+{
+namespace Error
+{
+struct IIC;
+} // namespace Error
+} // namespace Callout
+} // namespace Common
+} // namespace openbmc_project
+} // namespace xyz
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnErrorP5VPGOODFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerSequencerVoltageFault;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnErrorVddr0PGOODFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct GPUPowerFault;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnErrorVdd1PGOODFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnError240VaFaultFFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnErrorVtt0PGOODFail;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerOnErrorP3V3PGOODFail;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -394,6 +1174,1713 @@ namespace phosphor
 
 namespace logging
 {
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _Shutdown
+{
+
+} // namespace _Shutdown
+
+struct Shutdown
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::Shutdown>
+{
+    using type = org::open_power::Witherspoon::Fault::Shutdown;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnFailure
+{
+
+} // namespace _PowerOnFailure
+
+struct PowerOnFailure
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnFailure>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnFailure;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnError
+{
+
+} // namespace _PowerOnError
+
+struct PowerOnError
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnError>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnError;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PSUPresentError
+{
+
+} // namespace _PSUPresentError
+
+struct PSUPresentError
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::PSUPresentError>
+{
+    using type = org::open_power::Witherspoon::Fault::PSUPresentError;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorPSU0PGOODFail
+{
+
+} // namespace _PowerOnErrorPSU0PGOODFail
+
+struct PowerOnErrorPSU0PGOODFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnErrorPSU0PGOODFail>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorPSU0PGOODFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorPSU1PGOODFail
+{
+
+} // namespace _PowerOnErrorPSU1PGOODFail
+
+struct PowerOnErrorPSU1PGOODFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnErrorPSU1PGOODFail>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorPSU1PGOODFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnError240VaFaultAFail
+{
+
+} // namespace _PowerOnError240VaFaultAFail
+
+struct PowerOnError240VaFaultAFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnError240VaFaultAFail>
+{
+    using type =
+        org::open_power::Witherspoon::Fault::PowerOnError240VaFaultAFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnError240VaFaultBFail
+{
+
+} // namespace _PowerOnError240VaFaultBFail
+
+struct PowerOnError240VaFaultBFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnError240VaFaultBFail>
+{
+    using type =
+        org::open_power::Witherspoon::Fault::PowerOnError240VaFaultBFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnError240VaFaultCFail
+{
+
+} // namespace _PowerOnError240VaFaultCFail
+
+struct PowerOnError240VaFaultCFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnError240VaFaultCFail>
+{
+    using type =
+        org::open_power::Witherspoon::Fault::PowerOnError240VaFaultCFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnError240VaFaultDFail
+{
+
+} // namespace _PowerOnError240VaFaultDFail
+
+struct PowerOnError240VaFaultDFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnError240VaFaultDFail>
+{
+    using type =
+        org::open_power::Witherspoon::Fault::PowerOnError240VaFaultDFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnError240VaFaultEFail
+{
+
+} // namespace _PowerOnError240VaFaultEFail
+
+struct PowerOnError240VaFaultEFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnError240VaFaultEFail>
+{
+    using type =
+        org::open_power::Witherspoon::Fault::PowerOnError240VaFaultEFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnError240VaFaultFFail
+{
+
+} // namespace _PowerOnError240VaFaultFFail
+
+struct PowerOnError240VaFaultFFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnError240VaFaultFFail>
+{
+    using type =
+        org::open_power::Witherspoon::Fault::PowerOnError240VaFaultFFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnError240VaFaultGFail
+{
+
+} // namespace _PowerOnError240VaFaultGFail
+
+struct PowerOnError240VaFaultGFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnError240VaFaultGFail>
+{
+    using type =
+        org::open_power::Witherspoon::Fault::PowerOnError240VaFaultGFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnError240VaFaultHFail
+{
+
+} // namespace _PowerOnError240VaFaultHFail
+
+struct PowerOnError240VaFaultHFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnError240VaFaultHFail>
+{
+    using type =
+        org::open_power::Witherspoon::Fault::PowerOnError240VaFaultHFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnError240VaFaultJFail
+{
+
+} // namespace _PowerOnError240VaFaultJFail
+
+struct PowerOnError240VaFaultJFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnError240VaFaultJFail>
+{
+    using type =
+        org::open_power::Witherspoon::Fault::PowerOnError240VaFaultJFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnError240VaFaultKFail
+{
+
+} // namespace _PowerOnError240VaFaultKFail
+
+struct PowerOnError240VaFaultKFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnError240VaFaultKFail>
+{
+    using type =
+        org::open_power::Witherspoon::Fault::PowerOnError240VaFaultKFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnError240VaFaultLFail
+{
+
+} // namespace _PowerOnError240VaFaultLFail
+
+struct PowerOnError240VaFaultLFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnError240VaFaultLFail>
+{
+    using type =
+        org::open_power::Witherspoon::Fault::PowerOnError240VaFaultLFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorP5VPGOODFail
+{
+
+} // namespace _PowerOnErrorP5VPGOODFail
+
+struct PowerOnErrorP5VPGOODFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnErrorP5VPGOODFail>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorP5VPGOODFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorP3V3PGOODFail
+{
+
+} // namespace _PowerOnErrorP3V3PGOODFail
+
+struct PowerOnErrorP3V3PGOODFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnErrorP3V3PGOODFail>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorP3V3PGOODFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorP1V8PGOODFail
+{
+
+} // namespace _PowerOnErrorP1V8PGOODFail
+
+struct PowerOnErrorP1V8PGOODFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnErrorP1V8PGOODFail>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorP1V8PGOODFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorP1V1PGOODFail
+{
+
+} // namespace _PowerOnErrorP1V1PGOODFail
+
+struct PowerOnErrorP1V1PGOODFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnErrorP1V1PGOODFail>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorP1V1PGOODFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorP0V9PGOODFail
+{
+
+} // namespace _PowerOnErrorP0V9PGOODFail
+
+struct PowerOnErrorP0V9PGOODFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnErrorP0V9PGOODFail>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorP0V9PGOODFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorP2V5APGOODFail
+{
+
+} // namespace _PowerOnErrorP2V5APGOODFail
+
+struct PowerOnErrorP2V5APGOODFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnErrorP2V5APGOODFail>
+{
+    using type =
+        org::open_power::Witherspoon::Fault::PowerOnErrorP2V5APGOODFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorP2V5BPGOODFail
+{
+
+} // namespace _PowerOnErrorP2V5BPGOODFail
+
+struct PowerOnErrorP2V5BPGOODFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnErrorP2V5BPGOODFail>
+{
+    using type =
+        org::open_power::Witherspoon::Fault::PowerOnErrorP2V5BPGOODFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorVdn0PGOODFail
+{
+
+} // namespace _PowerOnErrorVdn0PGOODFail
+
+struct PowerOnErrorVdn0PGOODFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnErrorVdn0PGOODFail>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorVdn0PGOODFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorVdn1PGOODFail
+{
+
+} // namespace _PowerOnErrorVdn1PGOODFail
+
+struct PowerOnErrorVdn1PGOODFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnErrorVdn1PGOODFail>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorVdn1PGOODFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorP1V5PGOODFail
+{
+
+} // namespace _PowerOnErrorP1V5PGOODFail
+
+struct PowerOnErrorP1V5PGOODFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnErrorP1V5PGOODFail>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorP1V5PGOODFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorVio0PGOODFail
+{
+
+} // namespace _PowerOnErrorVio0PGOODFail
+
+struct PowerOnErrorVio0PGOODFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnErrorVio0PGOODFail>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorVio0PGOODFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorVio1PGOODFail
+{
+
+} // namespace _PowerOnErrorVio1PGOODFail
+
+struct PowerOnErrorVio1PGOODFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnErrorVio1PGOODFail>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorVio1PGOODFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorVdd0PGOODFail
+{
+
+} // namespace _PowerOnErrorVdd0PGOODFail
+
+struct PowerOnErrorVdd0PGOODFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnErrorVdd0PGOODFail>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorVdd0PGOODFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorVcs0PGOODFail
+{
+
+} // namespace _PowerOnErrorVcs0PGOODFail
+
+struct PowerOnErrorVcs0PGOODFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnErrorVcs0PGOODFail>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorVcs0PGOODFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorVdd1PGOODFail
+{
+
+} // namespace _PowerOnErrorVdd1PGOODFail
+
+struct PowerOnErrorVdd1PGOODFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnErrorVdd1PGOODFail>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorVdd1PGOODFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorVcs1PGOODFail
+{
+
+} // namespace _PowerOnErrorVcs1PGOODFail
+
+struct PowerOnErrorVcs1PGOODFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnErrorVcs1PGOODFail>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorVcs1PGOODFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorVddr0PGOODFail
+{
+
+} // namespace _PowerOnErrorVddr0PGOODFail
+
+struct PowerOnErrorVddr0PGOODFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnErrorVddr0PGOODFail>
+{
+    using type =
+        org::open_power::Witherspoon::Fault::PowerOnErrorVddr0PGOODFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorVtt0PGOODFail
+{
+
+} // namespace _PowerOnErrorVtt0PGOODFail
+
+struct PowerOnErrorVtt0PGOODFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnErrorVtt0PGOODFail>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorVtt0PGOODFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorVddr1PGOODFail
+{
+
+} // namespace _PowerOnErrorVddr1PGOODFail
+
+struct PowerOnErrorVddr1PGOODFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnErrorVddr1PGOODFail>
+{
+    using type =
+        org::open_power::Witherspoon::Fault::PowerOnErrorVddr1PGOODFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorVtt1PGOODFail
+{
+
+} // namespace _PowerOnErrorVtt1PGOODFail
+
+struct PowerOnErrorVtt1PGOODFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnErrorVtt1PGOODFail>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorVtt1PGOODFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorGPU0PGOODFail
+{
+
+} // namespace _PowerOnErrorGPU0PGOODFail
+
+struct PowerOnErrorGPU0PGOODFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnErrorGPU0PGOODFail>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorGPU0PGOODFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorGPU1PGOODFail
+{
+
+} // namespace _PowerOnErrorGPU1PGOODFail
+
+struct PowerOnErrorGPU1PGOODFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnErrorGPU1PGOODFail>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorGPU1PGOODFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorPSU0PSU1PGOODFail
+{
+
+} // namespace _PowerOnErrorPSU0PSU1PGOODFail
+
+struct PowerOnErrorPSU0PSU1PGOODFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnErrorPSU0PSU1PGOODFail>
+{
+    using type =
+        org::open_power::Witherspoon::Fault::PowerOnErrorPSU0PSU1PGOODFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCPLDRegisterFail
+{
+
+} // namespace _PowerOnErrorCPLDRegisterFail
+
+struct PowerOnErrorCPLDRegisterFail
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerOnErrorCPLDRegisterFail>
+{
+    using type =
+        org::open_power::Witherspoon::Fault::PowerOnErrorCPLDRegisterFail;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerSequencerVoltageFault
+{
+
+struct RAIL
+{
+    /*
+     * We can't use -fsanitize=undefined if we declare a
+     * 'static constexpr auto str' member, so don't. Instead, open-code the
+     * mako template lookups.
+     */
+    static constexpr auto str_short = "RAIL";
+    using type = std::tuple<std::decay_t<decltype("RAIL=%d")>, uint16_t>;
+    explicit constexpr RAIL(uint16_t a) : _entry(entry("RAIL=%d", a)){};
+    type _entry;
+};
+struct RAIL_NAME
+{
+    /*
+     * We can't use -fsanitize=undefined if we declare a
+     * 'static constexpr auto str' member, so don't. Instead, open-code the
+     * mako template lookups.
+     */
+    static constexpr auto str_short = "RAIL_NAME";
+    using type =
+        std::tuple<std::decay_t<decltype("RAIL_NAME=%s")>, const char*>;
+    explicit constexpr RAIL_NAME(const char* a) :
+        _entry(entry("RAIL_NAME=%s", a)){};
+    type _entry;
+};
+struct RAW_STATUS
+{
+    /*
+     * We can't use -fsanitize=undefined if we declare a
+     * 'static constexpr auto str' member, so don't. Instead, open-code the
+     * mako template lookups.
+     */
+    static constexpr auto str_short = "RAW_STATUS";
+    using type =
+        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
+    explicit constexpr RAW_STATUS(const char* a) :
+        _entry(entry("RAW_STATUS=%s", a)){};
+    type _entry;
+};
+
+} // namespace _PowerSequencerVoltageFault
+
+struct PowerSequencerVoltageFault
+{
+    static constexpr auto L = level::ERR;
+    using RAIL = _PowerSequencerVoltageFault::RAIL;
+    using RAIL_NAME = _PowerSequencerVoltageFault::RAIL_NAME;
+    using RAW_STATUS = _PowerSequencerVoltageFault::RAW_STATUS;
+    using metadata_types = std::tuple<RAIL, RAIL_NAME, RAW_STATUS>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerSequencerVoltageFault>
+{
+    using type =
+        org::open_power::Witherspoon::Fault::PowerSequencerVoltageFault;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerSequencerPGOODFault
+{
+
+struct INPUT_NUM
+{
+    /*
+     * We can't use -fsanitize=undefined if we declare a
+     * 'static constexpr auto str' member, so don't. Instead, open-code the
+     * mako template lookups.
+     */
+    static constexpr auto str_short = "INPUT_NUM";
+    using type = std::tuple<std::decay_t<decltype("INPUT_NUM=%d")>, uint16_t>;
+    explicit constexpr INPUT_NUM(uint16_t a) :
+        _entry(entry("INPUT_NUM=%d", a)){};
+    type _entry;
+};
+struct INPUT_NAME
+{
+    /*
+     * We can't use -fsanitize=undefined if we declare a
+     * 'static constexpr auto str' member, so don't. Instead, open-code the
+     * mako template lookups.
+     */
+    static constexpr auto str_short = "INPUT_NAME";
+    using type =
+        std::tuple<std::decay_t<decltype("INPUT_NAME=%s")>, const char*>;
+    explicit constexpr INPUT_NAME(const char* a) :
+        _entry(entry("INPUT_NAME=%s", a)){};
+    type _entry;
+};
+struct RAW_STATUS
+{
+    /*
+     * We can't use -fsanitize=undefined if we declare a
+     * 'static constexpr auto str' member, so don't. Instead, open-code the
+     * mako template lookups.
+     */
+    static constexpr auto str_short = "RAW_STATUS";
+    using type =
+        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
+    explicit constexpr RAW_STATUS(const char* a) :
+        _entry(entry("RAW_STATUS=%s", a)){};
+    type _entry;
+};
+
+} // namespace _PowerSequencerPGOODFault
+
+struct PowerSequencerPGOODFault
+{
+    static constexpr auto L = level::ERR;
+    using INPUT_NUM = _PowerSequencerPGOODFault::INPUT_NUM;
+    using INPUT_NAME = _PowerSequencerPGOODFault::INPUT_NAME;
+    using RAW_STATUS = _PowerSequencerPGOODFault::RAW_STATUS;
+    using metadata_types = std::tuple<INPUT_NUM, INPUT_NAME, RAW_STATUS>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerSequencerPGOODFault>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerSequencerPGOODFault;
+};
+
+} // namespace details
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerSequencerFault
+{
+
+struct RAW_STATUS
+{
+    /*
+     * We can't use -fsanitize=undefined if we declare a
+     * 'static constexpr auto str' member, so don't. Instead, open-code the
+     * mako template lookups.
+     */
+    static constexpr auto str_short = "RAW_STATUS";
+    using type =
+        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
+    explicit constexpr RAW_STATUS(const char* a) :
+        _entry(entry("RAW_STATUS=%s", a)){};
+    type _entry;
+};
+
+} // namespace _PowerSequencerFault
+
+struct PowerSequencerFault
+{
+    static constexpr auto L = level::ERR;
+    using RAW_STATUS = _PowerSequencerFault::RAW_STATUS;
+    using metadata_types = std::tuple<RAW_STATUS>;
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+namespace details
+{
+
+template <>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerSequencerFault>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerSequencerFault;
+};
+
+} // namespace details
 
 namespace xyz
 {
@@ -1019,292 +3506,6 @@ struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
 {
     using type =
         org::open_power::Witherspoon::Fault::PowerSupplyTemperatureFault;
-};
-
-} // namespace details
-
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace _Shutdown
-{
-
-} // namespace _Shutdown
-
-struct Shutdown
-{
-    static constexpr auto L = level::ERR;
-    using metadata_types = std::tuple<>;
-};
-
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-
-namespace details
-{
-
-template <>
-struct map_exception_type<
-    sdbusplus::org::open_power::Witherspoon::Fault::Error::Shutdown>
-{
-    using type = org::open_power::Witherspoon::Fault::Shutdown;
-};
-
-} // namespace details
-
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace _PowerOnFailure
-{
-
-} // namespace _PowerOnFailure
-
-struct PowerOnFailure
-{
-    static constexpr auto L = level::ERR;
-    using metadata_types = std::tuple<>;
-};
-
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-
-namespace details
-{
-
-template <>
-struct map_exception_type<
-    sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnFailure>
-{
-    using type = org::open_power::Witherspoon::Fault::PowerOnFailure;
-};
-
-} // namespace details
-
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace _PowerSequencerVoltageFault
-{
-
-struct RAIL
-{
-    /*
-     * We can't use -fsanitize=undefined if we declare a
-     * 'static constexpr auto str' member, so don't. Instead, open-code the
-     * mako template lookups.
-     */
-    static constexpr auto str_short = "RAIL";
-    using type = std::tuple<std::decay_t<decltype("RAIL=%d")>, uint16_t>;
-    explicit constexpr RAIL(uint16_t a) : _entry(entry("RAIL=%d", a)){};
-    type _entry;
-};
-struct RAIL_NAME
-{
-    /*
-     * We can't use -fsanitize=undefined if we declare a
-     * 'static constexpr auto str' member, so don't. Instead, open-code the
-     * mako template lookups.
-     */
-    static constexpr auto str_short = "RAIL_NAME";
-    using type =
-        std::tuple<std::decay_t<decltype("RAIL_NAME=%s")>, const char*>;
-    explicit constexpr RAIL_NAME(const char* a) :
-        _entry(entry("RAIL_NAME=%s", a)){};
-    type _entry;
-};
-struct RAW_STATUS
-{
-    /*
-     * We can't use -fsanitize=undefined if we declare a
-     * 'static constexpr auto str' member, so don't. Instead, open-code the
-     * mako template lookups.
-     */
-    static constexpr auto str_short = "RAW_STATUS";
-    using type =
-        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
-    explicit constexpr RAW_STATUS(const char* a) :
-        _entry(entry("RAW_STATUS=%s", a)){};
-    type _entry;
-};
-
-} // namespace _PowerSequencerVoltageFault
-
-struct PowerSequencerVoltageFault
-{
-    static constexpr auto L = level::ERR;
-    using RAIL = _PowerSequencerVoltageFault::RAIL;
-    using RAIL_NAME = _PowerSequencerVoltageFault::RAIL_NAME;
-    using RAW_STATUS = _PowerSequencerVoltageFault::RAW_STATUS;
-    using metadata_types = std::tuple<RAIL, RAIL_NAME, RAW_STATUS>;
-};
-
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-
-namespace details
-{
-
-template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
-                              Error::PowerSequencerVoltageFault>
-{
-    using type =
-        org::open_power::Witherspoon::Fault::PowerSequencerVoltageFault;
-};
-
-} // namespace details
-
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace _PowerSequencerPGOODFault
-{
-
-struct INPUT_NUM
-{
-    /*
-     * We can't use -fsanitize=undefined if we declare a
-     * 'static constexpr auto str' member, so don't. Instead, open-code the
-     * mako template lookups.
-     */
-    static constexpr auto str_short = "INPUT_NUM";
-    using type = std::tuple<std::decay_t<decltype("INPUT_NUM=%d")>, uint16_t>;
-    explicit constexpr INPUT_NUM(uint16_t a) :
-        _entry(entry("INPUT_NUM=%d", a)){};
-    type _entry;
-};
-struct INPUT_NAME
-{
-    /*
-     * We can't use -fsanitize=undefined if we declare a
-     * 'static constexpr auto str' member, so don't. Instead, open-code the
-     * mako template lookups.
-     */
-    static constexpr auto str_short = "INPUT_NAME";
-    using type =
-        std::tuple<std::decay_t<decltype("INPUT_NAME=%s")>, const char*>;
-    explicit constexpr INPUT_NAME(const char* a) :
-        _entry(entry("INPUT_NAME=%s", a)){};
-    type _entry;
-};
-struct RAW_STATUS
-{
-    /*
-     * We can't use -fsanitize=undefined if we declare a
-     * 'static constexpr auto str' member, so don't. Instead, open-code the
-     * mako template lookups.
-     */
-    static constexpr auto str_short = "RAW_STATUS";
-    using type =
-        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
-    explicit constexpr RAW_STATUS(const char* a) :
-        _entry(entry("RAW_STATUS=%s", a)){};
-    type _entry;
-};
-
-} // namespace _PowerSequencerPGOODFault
-
-struct PowerSequencerPGOODFault
-{
-    static constexpr auto L = level::ERR;
-    using INPUT_NUM = _PowerSequencerPGOODFault::INPUT_NUM;
-    using INPUT_NAME = _PowerSequencerPGOODFault::INPUT_NAME;
-    using RAW_STATUS = _PowerSequencerPGOODFault::RAW_STATUS;
-    using metadata_types = std::tuple<INPUT_NUM, INPUT_NAME, RAW_STATUS>;
-};
-
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-
-namespace details
-{
-
-template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
-                              Error::PowerSequencerPGOODFault>
-{
-    using type = org::open_power::Witherspoon::Fault::PowerSequencerPGOODFault;
-};
-
-} // namespace details
-
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace _PowerSequencerFault
-{
-
-struct RAW_STATUS
-{
-    /*
-     * We can't use -fsanitize=undefined if we declare a
-     * 'static constexpr auto str' member, so don't. Instead, open-code the
-     * mako template lookups.
-     */
-    static constexpr auto str_short = "RAW_STATUS";
-    using type =
-        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
-    explicit constexpr RAW_STATUS(const char* a) :
-        _entry(entry("RAW_STATUS=%s", a)){};
-    type _entry;
-};
-
-} // namespace _PowerSequencerFault
-
-struct PowerSequencerFault
-{
-    static constexpr auto L = level::ERR;
-    using RAW_STATUS = _PowerSequencerFault::RAW_STATUS;
-    using metadata_types = std::tuple<RAW_STATUS>;
-};
-
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-
-namespace details
-{
-
-template <>
-struct map_exception_type<
-    sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerSequencerFault>
-{
-    using type = org::open_power::Witherspoon::Fault::PowerSequencerFault;
 };
 
 } // namespace details

--- a/org/open_power/Witherspoon/Fault.errors.yaml
+++ b/org/open_power/Witherspoon/Fault.errors.yaml
@@ -24,6 +24,123 @@
 - name: PowerOnFailure
   description: System power failed to turn on
 
+- name: PowerOnError
+  description: Power failed to turn on
+
+- name: PSUPresentError
+  description: PSU failed to detect
+
+- name: PowerOnErrorPSU0PGOODFail
+  description: Power on error reason is PSU0_PGOOD fail
+
+- name: PowerOnErrorPSU1PGOODFail
+  description: Power on error reason is PSU1_PGOOD fail
+
+- name: PowerOnError240VaFaultAFail
+  description: Power on error reason is 240Va_Fault_A fail
+
+- name: PowerOnError240VaFaultBFail
+  description: Power on error reason is 240Va_Fault_B fail
+
+- name: PowerOnError240VaFaultCFail
+  description: Power on error reason is 240Va_Fault_C fail
+
+- name: PowerOnError240VaFaultDFail
+  description: Power on error reason is 240Va_Fault_D fail
+
+- name: PowerOnError240VaFaultEFail
+  description: Power on error reason is 240Va_Fault_E fail
+
+- name: PowerOnError240VaFaultFFail
+  description: Power on error reason is 240Va_Fault_F fail
+
+- name: PowerOnError240VaFaultGFail
+  description: Power on error reason is 240Va_Fault_G fail
+
+- name: PowerOnError240VaFaultHFail
+  description: Power on error reason is 240Va_Fault_H fail
+
+- name: PowerOnError240VaFaultJFail
+  description: Power on error reason is 240Va_Fault_J fail
+
+- name: PowerOnError240VaFaultKFail
+  description: Power on error reason is 240Va_Fault_K fail
+
+- name: PowerOnError240VaFaultLFail
+  description: Power on error reason is 240Va_Fault_L fail
+
+- name: PowerOnErrorP5VPGOODFail
+  description: Power on error reason is P5V_pgood fail
+
+- name: PowerOnErrorP3V3PGOODFail
+  description: Power on error reason is P3V3_pgood fail
+
+- name: PowerOnErrorP1V8PGOODFail
+  description: Power on error reason is P1V8_pgood fail
+
+- name: PowerOnErrorP1V1PGOODFail
+  description: Power on error reason is P1V1_pgood fail
+
+- name: PowerOnErrorP0V9PGOODFail
+  description: Power on error reason is P0V9_pgood fail
+
+- name: PowerOnErrorP2V5APGOODFail
+  description: Power on error reason is P2V5A_pgood fail
+
+- name: PowerOnErrorP2V5BPGOODFail
+  description: Power on error reason is P2V5B_pgood fail
+
+- name: PowerOnErrorVdn0PGOODFail
+  description: Power on error reason is Vdn0_pgood fail
+
+- name: PowerOnErrorVdn1PGOODFail
+  description: Power on error reason is Vdn1_pgood fail
+
+- name: PowerOnErrorP1V5PGOODFail
+  description: Power on error reason is P1V5_pgood fail
+
+- name: PowerOnErrorVio0PGOODFail
+  description: Power on error reason is Vio0_pgood fail
+
+- name: PowerOnErrorVio1PGOODFail
+  description: Power on error reason is Vio1_pgood fail
+
+- name: PowerOnErrorVdd0PGOODFail
+  description: Power on error reason is Vdd0_pgood fail
+
+- name: PowerOnErrorVcs0PGOODFail
+  description: Power on error reason is Vcs0_pgood fail
+
+- name: PowerOnErrorVdd1PGOODFail
+  description: Power on error reason is Vdd1_pgood fail
+
+- name: PowerOnErrorVcs1PGOODFail
+  description: Power on error reason is Vcs1_pgood fail
+
+- name: PowerOnErrorVddr0PGOODFail
+  description: Power on error reason is Vddr0_pgood fail
+
+- name: PowerOnErrorVtt0PGOODFail
+  description: Power on error reason is Vtt0_pgood fail
+
+- name: PowerOnErrorVddr1PGOODFail
+  description: Power on error reason is Vddr1_pgood fail
+
+- name: PowerOnErrorVtt1PGOODFail
+  description: Power on error reason is Vtt1_pgood fail
+
+- name: PowerOnErrorGPU0PGOODFail
+  description: Power on error reason is GPU0_pgood fail
+
+- name: PowerOnErrorGPU1PGOODFail
+  description: Power on error reason is GPU1_pgood fail
+
+- name: PowerOnErrorPSU0PSU1PGOODFail
+  description: Power on error reason is PSU0&PSU1_pgood fail
+
+- name: PowerOnErrorCPLDRegisterFail
+  description: Read CPLD-register fail
+
 - name: PowerSequencerVoltageFault
   description: The power sequencer chip detected a voltage fault
 

--- a/org/open_power/Witherspoon/Fault.metadata.yaml
+++ b/org/open_power/Witherspoon/Fault.metadata.yaml
@@ -52,6 +52,123 @@
 - name: PowerOnFailure
   level: ERR
 
+- name: PowerOnError
+  level: ERR
+
+- name: PSUPresentError
+  level: ERR
+
+- name: PowerOnErrorPSU0PGOODFail
+  level: ERR
+
+- name: PowerOnErrorPSU1PGOODFail
+  level: ERR
+
+- name: PowerOnError240VaFaultAFail
+  level: ERR
+
+- name: PowerOnError240VaFaultBFail
+  level: ERR
+
+- name: PowerOnError240VaFaultCFail
+  level: ERR
+
+- name: PowerOnError240VaFaultDFail
+  level: ERR
+
+- name: PowerOnError240VaFaultEFail
+  level: ERR
+
+- name: PowerOnError240VaFaultFFail
+  level: ERR
+
+- name: PowerOnError240VaFaultGFail
+  level: ERR
+
+- name: PowerOnError240VaFaultHFail
+  level: ERR
+
+- name: PowerOnError240VaFaultJFail
+  level: ERR
+
+- name: PowerOnError240VaFaultKFail
+  level: ERR
+
+- name: PowerOnError240VaFaultLFail
+  level: ERR
+
+- name: PowerOnErrorP5VPGOODFail
+  level: ERR
+
+- name: PowerOnErrorP3V3PGOODFail
+  level: ERR
+
+- name: PowerOnErrorP1V8PGOODFail
+  level: ERR
+
+- name: PowerOnErrorP1V1PGOODFail
+  level: ERR
+
+- name: PowerOnErrorP0V9PGOODFail
+  level: ERR
+
+- name: PowerOnErrorP2V5APGOODFail
+  level: ERR
+
+- name: PowerOnErrorP2V5BPGOODFail
+  level: ERR
+
+- name: PowerOnErrorVdn0PGOODFail
+  level: ERR
+
+- name: PowerOnErrorVdn1PGOODFail
+  level: ERR
+
+- name: PowerOnErrorP1V5PGOODFail
+  level: ERR
+
+- name: PowerOnErrorVio0PGOODFail
+  level: ERR
+
+- name: PowerOnErrorVio1PGOODFail
+  level: ERR
+
+- name: PowerOnErrorVdd0PGOODFail
+  level: ERR
+
+- name: PowerOnErrorVcs0PGOODFail
+  level: ERR
+
+- name: PowerOnErrorVdd1PGOODFail
+  level: ERR
+
+- name: PowerOnErrorVcs1PGOODFail
+  level: ERR
+
+- name: PowerOnErrorVddr0PGOODFail
+  level: ERR
+
+- name: PowerOnErrorVtt0PGOODFail
+  level: ERR
+
+- name: PowerOnErrorVddr1PGOODFail
+  level: ERR
+
+- name: PowerOnErrorVtt1PGOODFail
+  level: ERR
+
+- name: PowerOnErrorGPU0PGOODFail
+  level: ERR
+
+- name: PowerOnErrorGPU1PGOODFail
+  level: ERR
+
+- name: PowerOnErrorPSU0PSU1PGOODFail
+  level: ERR
+
+- name: PowerOnErrorCPLDRegisterFail
+  level: ERR
+
 - name: PowerSequencerVoltageFault
   level: ERR
   meta:

--- a/power-sequencer/Makefile.am
+++ b/power-sequencer/Makefile.am
@@ -10,13 +10,13 @@ pseq_monitor_SOURCES = \
 	pgood_monitor.cpp \
 	runtime_monitor.cpp \
 	ucd90160.cpp \
-        mihawk-cpld.cpp
+	mihawk-cpld.cpp
 
 nodist_pseq_monitor_SOURCES = \
 	ucd90160_defs.cpp
 
 pseq_monitor_LDADD = \
-        -li2c \
+	-li2c \
 	$(top_builddir)/libpower.la \
 	$(PHOSPHOR_LOGGING_LIBS) \
 	${PHOSPHOR_DBUS_INTERFACES_LIBS} \

--- a/power-sequencer/Makefile.am
+++ b/power-sequencer/Makefile.am
@@ -9,12 +9,14 @@ pseq_monitor_SOURCES = \
 	main.cpp \
 	pgood_monitor.cpp \
 	runtime_monitor.cpp \
-	ucd90160.cpp
+	ucd90160.cpp \
+        mihawk-cpld.cpp
 
 nodist_pseq_monitor_SOURCES = \
 	ucd90160_defs.cpp
 
 pseq_monitor_LDADD = \
+        -li2c \
 	$(top_builddir)/libpower.la \
 	$(PHOSPHOR_LOGGING_LIBS) \
 	${PHOSPHOR_DBUS_INTERFACES_LIBS} \

--- a/power-sequencer/mihawk-cpld.cpp
+++ b/power-sequencer/mihawk-cpld.cpp
@@ -1,0 +1,478 @@
+#include "config.h"
+
+#include "mihawk-cpld.hpp"
+
+#include "utility.hpp"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <elog-errors.hpp>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <org/open_power/Witherspoon/Fault/error.hpp>
+#include <phosphor-logging/elog.hpp>
+#include <phosphor-logging/log.hpp>
+#include <string>
+#include <xyz/openbmc_project/Common/Device/error.hpp>
+
+extern "C" {
+#include <i2c/smbus.h>
+#include <linux/i2c-dev.h>
+#include <linux/i2c.h>
+}
+
+// i2c bus & i2c slave address of Mihawk's CPLD
+#define busId 11
+#define slaveAddr 0x40
+
+// SMLink Status Register(PSU Register)
+const static constexpr size_t StatusReg = 0x05;
+
+// SMLink Status Register(Interrupt-control-bit Register)
+const static constexpr size_t StatusReg_1 = 0x20;
+
+// SMLink Status Register(Power-on error code Register)
+const static constexpr size_t StatusReg_2 = 0x21;
+
+using namespace std;
+namespace witherspoon
+{
+namespace power
+{
+const auto DEVICE_NAME = "MihawkCPLD"s;
+
+namespace fs = std::filesystem;
+using namespace phosphor::logging;
+
+using namespace sdbusplus::org::open_power::Witherspoon::Fault::Error;
+
+namespace device_error = sdbusplus::xyz::openbmc_project::Common::Device::Error;
+
+MihawkCPLD::MihawkCPLD(size_t instance, sdbusplus::bus::bus& bus) :
+    Device(DEVICE_NAME, instance), bus(bus)
+{
+}
+
+void MihawkCPLD::onFailure()
+{
+    bool psuError = checkPSUdevice();
+    bool poweronError = checkPoweronFault();
+
+    if (psuError)
+    {
+        // If PSU not present, report the error log & event.
+        report<PSUPresentError>();
+        std::cerr << "CPLD : PSU Present Error! \n";
+    }
+
+    // If the interrupt of power_on_error is switch on,
+    // read CPLD_register error code to analyze and report the error log
+    // & event.
+    if (poweronError)
+    {
+        std::cerr << "CPLD : Power_ON error! \n";
+        int errorcode;
+        errorcode = readFromCPLDPSUErrorCode(busId, slaveAddr);
+        if (errorcode == 0)
+        {
+            report<PowerOnErrorCPLDRegisterFail>();
+            std::cerr << "Power_on error : Read CPLD-register fail! \n";
+        }
+        else if (errorcode == 1)
+        {
+            report<PowerOnErrorPSU0PGOODFail>();
+            std::cerr << "Power_on error : psu0_pgood fail! \n";
+        }
+        else if (errorcode == 2)
+        {
+            report<PowerOnErrorPSU1PGOODFail>();
+            std::cerr << "Power_on error : psu1_pgood fail! \n";
+        }
+        else if (errorcode == 3)
+        {
+            report<PowerOnError240VaFaultAFail>();
+            std::cerr << "Power_on error : 240Va_Fault_A fail! \n";
+        }
+        else if (errorcode == 4)
+        {
+            report<PowerOnError240VaFaultBFail>();
+            std::cerr << "Power_on error : 240Va_Fault_B fail! \n";
+        }
+        else if (errorcode == 5)
+        {
+            report<PowerOnError240VaFaultCFail>();
+            std::cerr << "Power_on error : 240Va_Fault_C fail! \n";
+        }
+        else if (errorcode == 6)
+        {
+            report<PowerOnError240VaFaultDFail>();
+            std::cerr << "Power_on error : 240Va_Fault_D fail! \n";
+        }
+        else if (errorcode == 7)
+        {
+            report<PowerOnError240VaFaultEFail>();
+            std::cerr << "Power_on error : 240Va_Fault_E fail! \n";
+        }
+        else if (errorcode == 8)
+        {
+            report<PowerOnError240VaFaultFFail>();
+            std::cerr << "Power_on error : 240Va_Fault_F fail! \n";
+        }
+        else if (errorcode == 9)
+        {
+            report<PowerOnError240VaFaultGFail>();
+            std::cerr << "Power_on error : 240Va_Fault_G fail! \n";
+        }
+        else if (errorcode == 10)
+        {
+            report<PowerOnError240VaFaultHFail>();
+            std::cerr << "Power_on error : 240Va_Fault_H fail! \n";
+        }
+        else if (errorcode == 11)
+        {
+            report<PowerOnError240VaFaultJFail>();
+            std::cerr << "Power_on error : 240Va_Fault_J fail! \n";
+        }
+        else if (errorcode == 12)
+        {
+            report<PowerOnError240VaFaultKFail>();
+            std::cerr << "Power_on error : 240Va_Fault_K fail! \n";
+        }
+        else if (errorcode == 13)
+        {
+            report<PowerOnError240VaFaultLFail>();
+            std::cerr << "Power_on error : 240Va_Fault_L fail! \n";
+        }
+        else if (errorcode == 14)
+        {
+            report<PowerOnErrorP5VPGOODFail>();
+            std::cerr << "Power_on error : P5V_pgood fail! \n";
+        }
+        else if (errorcode == 15)
+        {
+            report<PowerOnErrorP3V3PGOODFail>();
+            std::cerr << "Power_on error : P3V3_pgood fail! \n";
+        }
+        else if (errorcode == 16)
+        {
+            report<PowerOnErrorP1V8PGOODFail>();
+            std::cerr << "Power_on error : P1V8_pgood fail! \n";
+        }
+        else if (errorcode == 17)
+        {
+            report<PowerOnErrorP1V1PGOODFail>();
+            std::cerr << "Power_on error : P1V1_pgood fail! \n";
+        }
+        else if (errorcode == 18)
+        {
+            report<PowerOnErrorP0V9PGOODFail>();
+            std::cerr << "Power_on error : P0V9_pgood fail! \n";
+        }
+        else if (errorcode == 19)
+        {
+            report<PowerOnErrorP2V5APGOODFail>();
+            std::cerr << "Power_on error : P2V5A_pgood fail! \n";
+        }
+        else if (errorcode == 20)
+        {
+            report<PowerOnErrorP2V5BPGOODFail>();
+            std::cerr << "Power_on error : P2V5B_pgood fail! \n";
+        }
+        else if (errorcode == 21)
+        {
+            report<PowerOnErrorVdn0PGOODFail>();
+            std::cerr << "Power_on error : Vdn0_pgood fail! \n";
+        }
+        else if (errorcode == 22)
+        {
+            report<PowerOnErrorVdn1PGOODFail>();
+            std::cerr << "Power_on error : Vdn1_pgood fail! \n";
+        }
+        else if (errorcode == 23)
+        {
+            report<PowerOnErrorP1V5PGOODFail>();
+            std::cerr << "Power_on error : P1V5_pgood fail! \n";
+        }
+        else if (errorcode == 24)
+        {
+            report<PowerOnErrorVio0PGOODFail>();
+            std::cerr << "Power_on error : Vio0_pgood fail! \n";
+        }
+        else if (errorcode == 25)
+        {
+            report<PowerOnErrorVio1PGOODFail>();
+            std::cerr << "Power_on error : Vio1_pgood fail! \n";
+        }
+        else if (errorcode == 26)
+        {
+            report<PowerOnErrorVdd0PGOODFail>();
+            std::cerr << "Power_on error : Vdd0_pgood fail! \n";
+        }
+        else if (errorcode == 27)
+        {
+            report<PowerOnErrorVcs0PGOODFail>();
+            std::cerr << "Power_on error : Vcs0_pgood fail! \n";
+        }
+        else if (errorcode == 28)
+        {
+            report<PowerOnErrorVdd1PGOODFail>();
+            std::cerr << "Power_on error : Vdd1_pgood fail! \n";
+        }
+        else if (errorcode == 29)
+        {
+            report<PowerOnErrorVcs1PGOODFail>();
+            std::cerr << "Power_on error : Vcs1_pgood fail! \n";
+        }
+        else if (errorcode == 30)
+        {
+            report<PowerOnErrorVddr0PGOODFail>();
+            std::cerr << "Power_on error : Vddr0_pgood fail! \n";
+        }
+        else if (errorcode == 31)
+        {
+            report<PowerOnErrorVtt0PGOODFail>();
+            std::cerr << "Power_on error : Vtt0_pgood fail! \n";
+        }
+        else if (errorcode == 32)
+        {
+            report<PowerOnErrorVddr1PGOODFail>();
+            std::cerr << "Power_on error : Vddr1_pgood fail! \n";
+        }
+        else if (errorcode == 33)
+        {
+            report<PowerOnErrorVtt1PGOODFail>();
+            std::cerr << "Power_on error : Vtt1_pgood fail! \n";
+        }
+        else if (errorcode == 34)
+        {
+            report<PowerOnErrorGPU0PGOODFail>();
+            std::cerr << "Power_on error : GPU0_pgood fail! \n";
+        }
+        else if (errorcode == 35)
+        {
+            report<PowerOnErrorGPU1PGOODFail>();
+            std::cerr << "Power_on error : GPU1_pgood fail! \n";
+        }
+        else if (errorcode == 170)
+        {
+            report<PowerOnErrorPSU0PSU1PGOODFail>();
+            std::cerr << "Power_on error : Psu0&PSU1_pgood fail! \n";
+        }
+    }
+}
+
+void MihawkCPLD::analyze()
+{
+    bool psuError = checkPSUdevice();
+    if (psuError)
+    {
+        // If PSU not present, report the error log & event.
+        report<PSUPresentError>();
+        std::cerr << "CPLD : PSU Present Error! \n";
+    }
+}
+
+// Read CPLD_register error code and return the result to analyze.
+int MihawkCPLD::readFromCPLDPSUErrorCode(int bus, int Addr)
+{
+    std::string i2cBus = "/dev/i2c-" + std::to_string(bus);
+
+    // open i2c device(CPLD-PSU-register table)
+    int fd = open(i2cBus.c_str(), O_RDWR | O_CLOEXEC);
+    if (fd < 0)
+    {
+        std::cerr << "Unable to open i2c device \n";
+    }
+
+    // set i2c slave address
+    if (ioctl(fd, I2C_SLAVE_FORCE, Addr) < 0)
+    {
+        std::cerr << "Unable to set device address \n";
+        close(fd);
+    }
+
+    // check whether support i2c function
+    unsigned long funcs = 0;
+    if (ioctl(fd, I2C_FUNCS, &funcs) < 0)
+    {
+        std::cerr << "Not support I2C_FUNCS \n";
+        close(fd);
+    }
+
+    // check whether support i2c-read function
+    if (!(funcs & I2C_FUNC_SMBUS_READ_BYTE_DATA))
+    {
+        std::cerr << "Not support I2C_FUNC_SMBUS_READ_BYTE_DATA \n";
+        close(fd);
+    }
+
+    int statusValue_2;
+    unsigned int statusReg_2 = StatusReg_2;
+
+    statusValue_2 = i2c_smbus_read_byte_data(fd, statusReg_2);
+    close(fd);
+
+    if (statusValue_2 < 0)
+    {
+        statusValue_2 = 0;
+    }
+
+    // return the i2c-read data
+    return statusValue_2;
+}
+
+// Check PSU_present_pin.
+bool MihawkCPLD::checkPSUdevice()
+{
+    bool result = 0;
+    int bin[32], num;
+    int i = 0, length = 0;
+    std::string i2cBus = "/dev/i2c-" + std::to_string(busId);
+
+    // open i2c device(CPLD-PSU-register table)
+    int fd = open(i2cBus.c_str(), O_RDWR | O_CLOEXEC);
+    if (fd < 0)
+    {
+        std::cerr << "Unable to open i2c device \n";
+    }
+
+    // set i2c slave address
+    if (ioctl(fd, I2C_SLAVE_FORCE, slaveAddr) < 0)
+    {
+        std::cerr << "Unable to set device address \n";
+        close(fd);
+    }
+
+    // check whether support i2c function
+    unsigned long funcs = 0;
+    if (ioctl(fd, I2C_FUNCS, &funcs) < 0)
+    {
+        std::cerr << "Not support I2C_FUNCS \n";
+        close(fd);
+    }
+
+    // check whether support i2c-read function
+    if (!(funcs & I2C_FUNC_SMBUS_READ_BYTE_DATA))
+    {
+        std::cerr << "Not support I2C_FUNC_SMBUS_READ_BYTE_DATA \n";
+        close(fd);
+    }
+
+    int statusValue;
+    unsigned int statusReg = StatusReg;
+
+    statusValue = i2c_smbus_read_byte_data(fd, statusReg);
+    close(fd);
+
+    if (statusValue < 0)
+    {
+        std::cerr << "i2c_smbus_read_byte_data failed \n";
+    }
+
+    // Transfer decimal_value to binary_value
+    num = statusValue;
+    do
+    {
+        bin[i] = num % 2;
+        num = num / 2;
+        i++;
+        length++;
+    } while (num != 1);
+    bin[length] = num;
+    length++;
+
+    if (bin[3] == 1 && bin[4] == 1)
+    {
+        // If power_on-interrupt-bit is read as 1,
+        // switch on the flag.
+        result = 1;
+    }
+    else
+    {
+        result = 0;
+    }
+
+    return result;
+}
+
+// Check for PoweronFault
+bool MihawkCPLD::checkPoweronFault()
+{
+    bool result_1 = 0;
+    int bin1[32], num1;
+    int i = 0, length = 0;
+    std::string i2cBus = "/dev/i2c-" + std::to_string(busId);
+
+    // open i2c device(CPLD-PSU-register table)
+    int fd = open(i2cBus.c_str(), O_RDWR | O_CLOEXEC);
+    if (fd < 0)
+    {
+        std::cerr << "Unable to open i2c device \n";
+    }
+
+    // set i2c slave address
+    if (ioctl(fd, I2C_SLAVE_FORCE, slaveAddr) < 0)
+    {
+        std::cerr << "Unable to set device address \n";
+        close(fd);
+    }
+
+    // check whether support i2c function
+    unsigned long funcs = 0;
+    if (ioctl(fd, I2C_FUNCS, &funcs) < 0)
+    {
+        std::cerr << "Not support I2C_FUNCS \n";
+        close(fd);
+    }
+
+    // check whether support i2c-read function
+    if (!(funcs & I2C_FUNC_SMBUS_READ_BYTE_DATA))
+    {
+        std::cerr << "Not support I2C_FUNC_SMBUS_READ_BYTE_DATA \n";
+        close(fd);
+    }
+
+    int statusValue_1;
+    unsigned int statusReg_1 = StatusReg_1;
+
+    statusValue_1 = i2c_smbus_read_byte_data(fd, statusReg_1);
+    close(fd);
+
+    if (statusValue_1 < 0)
+    {
+        std::cerr << "i2c_smbus_read_byte_data failed \n";
+    }
+
+    // Transfer decimal_value to binary_value
+    num1 = statusValue_1;
+    do
+    {
+        bin1[i] = num1 % 2;
+        num1 = num1 / 2;
+        i++;
+        length++;
+    } while (num1 != 1);
+    bin1[length] = num1;
+    length++;
+
+    if (bin1[5] == 1)
+    {
+        // If power_on-interrupt-bit is read as 1,
+        // switch on the flag.
+        result_1 = 1;
+    }
+    else
+    {
+        result_1 = 0;
+    }
+
+    return result_1;
+}
+
+} // namespace power
+} // namespace witherspoon

--- a/power-sequencer/mihawk-cpld.hpp
+++ b/power-sequencer/mihawk-cpld.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+#include "device.hpp"
+#include "pmbus.hpp"
+
+#include <algorithm>
+#include <filesystem>
+#include <sdbusplus/bus.hpp>
+
+namespace witherspoon
+{
+namespace power
+{
+
+/**
+ * @class MihawkCPLD
+ *
+ * This class implements fault analysis for Mihawk's CPLD
+ * power sequencer device.
+ *
+ */
+class MihawkCPLD : public Device
+{
+  public:
+    MihawkCPLD() = delete;
+    ~MihawkCPLD() = default;
+    MihawkCPLD(const MihawkCPLD&) = delete;
+    MihawkCPLD& operator=(const MihawkCPLD&) = delete;
+    MihawkCPLD(MihawkCPLD&&) = default;
+    MihawkCPLD& operator=(MihawkCPLD&&) = default;
+
+    /**
+     * Constructor
+     *
+     * @param[in] instance - the device instance number
+     * @param[in] bus - D-Bus bus object
+     */
+    MihawkCPLD(size_t instance, sdbusplus::bus::bus& bus);
+
+    /**
+     * Analyzes the device for errors when the device is
+     * known to be in an error state.  A log will be created.
+     */
+    void onFailure() override;
+
+    /**
+     * Checks the device for errors and only creates a log
+     * if one is found.
+     */
+    void analyze() override;
+
+    /**
+     * Clears faults in the device
+     */
+    void clearFaults() override
+    {
+    }
+
+  private:
+    /**
+     * If checkPoweronFault() returns "true",
+     * use ReadFromCPLDPSUErrorCode() to read CPLD-error-code-register
+     * to analyze the fail reason.
+     *
+     * @param[in] bus - I2C's bus, ex.i2c-11.
+     * Mihawk's CPLD-register is on i2c-11.
+     *
+     * @param[in] Addr - the i2c-11 address of Mihawk's CPLD-register.
+     *
+     * @return int - the error-code value which is read on
+     * CPLD-error-code-register.
+     */
+    int readFromCPLDPSUErrorCode(int bus, int Addr);
+
+    /**
+     * Checks for PoweronFault on Mihawk's
+     * CPLD-power_on-error-interrupt-bit-register
+     * whether is transfered to "1".
+     *
+     * @return bool - true if power_on fail.
+     */
+    bool checkPoweronFault();
+
+    /**
+     * Checks for PSU0 & PSU1 whether are "present".
+     *
+     * @return bool - true if PSU0 & PSU1 aren't "present".
+     */
+    bool checkPSUdevice();
+
+    /**
+     * The D-Bus bus object
+     */
+    sdbusplus::bus::bus& bus;
+};
+
+} // namespace power
+} // namespace witherspoon


### PR DESCRIPTION
If PGOOD signal is abnormal when chassis poweron, read
Mihawk's CPLD-register via I2C to confirm the error.

First confirm whether the PSU is present, then confirm
whether the power_on_error signal is 1 (1 means abnormal).
If the signal is 1, read the error-code-register to
analysis reason.


Since the openbmc/master part is constantly being updated, 
I will sent a "pull requset" on the ibm-openbmc/OP940 for
Mihawk.
https://gerrit.openbmc-project.xyz/c/openbmc/witherspoon-pfault-analysis/+/25028/19
