### PR TITLE
Add CPLD class for Mihawk platform on witherspoon-pfault-analysis 

### DIFF
--- a/elog-errors.hpp
+++ b/elog-errors.hpp
@@ -2,12 +2,12 @@
 // See elog-gen.py for more details
 #pragma once
 
-#include <phosphor-logging/elog.hpp>
-#include <phosphor-logging/log.hpp>
-#include <sdbusplus/exception.hpp>
 #include <string>
 #include <tuple>
 #include <type_traits>
+#include <sdbusplus/exception.hpp>
+#include <phosphor-logging/log.hpp>
+#include <phosphor-logging/elog.hpp>
 
 namespace sdbusplus
 {
@@ -21,27 +21,7 @@ namespace Fault
 {
 namespace Error
 {
-struct PowerSequencerPGOODFault;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-struct MemoryPowerFault;
+    struct MemoryPowerFault;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -61,7 +41,7 @@ namespace Callout
 {
 namespace Error
 {
-struct GPIO;
+    struct Device;
 } // namespace Error
 } // namespace Callout
 } // namespace Common
@@ -81,27 +61,7 @@ namespace Fault
 {
 namespace Error
 {
-struct PowerOnFailure;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-struct PowerSupplyInputFault;
+    struct PowerSequencerPGOODFault;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -121,7 +81,7 @@ namespace Callout
 {
 namespace Error
 {
-struct IIC;
+    struct GPIO;
 } // namespace Error
 } // namespace Callout
 } // namespace Common
@@ -141,7 +101,7 @@ namespace Fault
 {
 namespace Error
 {
-struct GPUPowerFault;
+    struct PowerSequencerVoltageFault;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -161,7 +121,387 @@ namespace Fault
 {
 namespace Error
 {
-struct Shutdown;
+    struct PSUPresentError;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode10;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode11;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode12;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode13;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnFailure;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode15;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode16;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode17;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode18;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode19;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct Shutdown;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode31;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode36;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode34;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode35;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerSupplyTemperatureFault;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerSupplyFanFault;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerSupplyShouldBeOn;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode30;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -181,27 +521,7 @@ namespace Callout
 {
 namespace Error
 {
-struct Inventory;
-} // namespace Error
-} // namespace Callout
-} // namespace Common
-} // namespace openbmc_project
-} // namespace xyz
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace xyz
-{
-namespace openbmc_project
-{
-namespace Common
-{
-namespace Callout
-{
-namespace Error
-{
-struct Device;
+    struct IIC;
 } // namespace Error
 } // namespace Callout
 } // namespace Common
@@ -221,7 +541,7 @@ namespace Fault
 {
 namespace Error
 {
-struct PowerSequencerFault;
+    struct PowerSupplyOutputOvercurrent;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -241,7 +561,7 @@ namespace Fault
 {
 namespace Error
 {
-struct PowerSupplyOutputOvercurrent;
+    struct PowerSupplyInputFault;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -261,47 +581,7 @@ namespace Fault
 {
 namespace Error
 {
-struct PowerSupplyOutputOvervoltage;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-struct PowerSupplyFanFault;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-struct PowerSequencerVoltageFault;
+    struct PowerOnErrorCode14;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -321,7 +601,7 @@ namespace Callout
 {
 namespace Error
 {
-struct IPMISensor;
+    struct IPMISensor;
 } // namespace Error
 } // namespace Callout
 } // namespace Common
@@ -341,7 +621,7 @@ namespace Fault
 {
 namespace Error
 {
-struct PowerSupplyTemperatureFault;
+    struct PowerSequencerFault;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -361,7 +641,7 @@ namespace Fault
 {
 namespace Error
 {
-struct PowerSupplyShouldBeOn;
+    struct GPUOverTemp;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -381,647 +661,500 @@ namespace Fault
 {
 namespace Error
 {
-struct GPUOverTemp;
+    struct PowerOnErrorCode29;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
 } // namespace open_power
 } // namespace org
 } // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode28;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerSupplyOutputOvervoltage;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace xyz
+{
+namespace openbmc_project
+{
+namespace Common
+{
+namespace Callout
+{
+namespace Error
+{
+    struct Inventory;
+} // namespace Error
+} // namespace Callout
+} // namespace Common
+} // namespace openbmc_project
+} // namespace xyz
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode21;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode20;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode23;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode22;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode25;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode24;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode27;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode26;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode32;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode8;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode9;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct GPUPowerFault;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode33;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode2;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode3;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode0;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode1;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode6;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode7;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode4;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+    struct PowerOnErrorCode5;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
 
 namespace phosphor
 {
 
 namespace logging
 {
-
-namespace xyz
-{
-namespace openbmc_project
-{
-namespace Common
-{
-namespace Callout
-{
-namespace _Device
-{
-
-struct CALLOUT_ERRNO
-{
-    /*
-     * We can't use -fsanitize=undefined if we declare a
-     * 'static constexpr auto str' member, so don't. Instead, open-code the
-     * mako template lookups.
-     */
-    static constexpr auto str_short = "CALLOUT_ERRNO";
-    using type =
-        std::tuple<std::decay_t<decltype("CALLOUT_ERRNO=%d")>, int32_t>;
-    explicit constexpr CALLOUT_ERRNO(int32_t a) :
-        _entry(entry("CALLOUT_ERRNO=%d", a)){};
-    type _entry;
-};
-struct CALLOUT_DEVICE_PATH
-{
-    /*
-     * We can't use -fsanitize=undefined if we declare a
-     * 'static constexpr auto str' member, so don't. Instead, open-code the
-     * mako template lookups.
-     */
-    static constexpr auto str_short = "CALLOUT_DEVICE_PATH";
-    using type = std::tuple<std::decay_t<decltype("CALLOUT_DEVICE_PATH=%s")>,
-                            const char*>;
-    explicit constexpr CALLOUT_DEVICE_PATH(const char* a) :
-        _entry(entry("CALLOUT_DEVICE_PATH=%s", a)){};
-    type _entry;
-};
-
-} // namespace _Device
-
-struct Device
-{
-    static constexpr auto L = level::ERR;
-    using CALLOUT_ERRNO = _Device::CALLOUT_ERRNO;
-    using CALLOUT_DEVICE_PATH = _Device::CALLOUT_DEVICE_PATH;
-    using metadata_types = std::tuple<CALLOUT_ERRNO, CALLOUT_DEVICE_PATH>;
-};
-
-} // namespace Callout
-} // namespace Common
-} // namespace openbmc_project
-} // namespace xyz
-
-namespace details
-{
-
-template <>
-struct map_exception_type<
-    sdbusplus::xyz::openbmc_project::Common::Callout::Error::Device>
-{
-    using type = xyz::openbmc_project::Common::Callout::Device;
-};
-
-} // namespace details
-
-namespace xyz
-{
-namespace openbmc_project
-{
-namespace Common
-{
-namespace Callout
-{
-namespace _GPIO
-{
-
-struct CALLOUT_GPIO_NUM
-{
-    /*
-     * We can't use -fsanitize=undefined if we declare a
-     * 'static constexpr auto str' member, so don't. Instead, open-code the
-     * mako template lookups.
-     */
-    static constexpr auto str_short = "CALLOUT_GPIO_NUM";
-    using type =
-        std::tuple<std::decay_t<decltype("CALLOUT_GPIO_NUM=%u")>, uint32_t>;
-    explicit constexpr CALLOUT_GPIO_NUM(uint32_t a) :
-        _entry(entry("CALLOUT_GPIO_NUM=%u", a)){};
-    type _entry;
-};
-
-} // namespace _GPIO
-
-struct GPIO
-{
-    static constexpr auto L = level::ERR;
-    using CALLOUT_GPIO_NUM = _GPIO::CALLOUT_GPIO_NUM;
-    using CALLOUT_ERRNO =
-        xyz::openbmc_project::Common::Callout::Device::CALLOUT_ERRNO;
-    using CALLOUT_DEVICE_PATH =
-        xyz::openbmc_project::Common::Callout::Device::CALLOUT_DEVICE_PATH;
-    using metadata_types =
-        std::tuple<CALLOUT_GPIO_NUM, CALLOUT_ERRNO, CALLOUT_DEVICE_PATH>;
-};
-
-} // namespace Callout
-} // namespace Common
-} // namespace openbmc_project
-} // namespace xyz
-
-namespace details
-{
-
-template <>
-struct map_exception_type<
-    sdbusplus::xyz::openbmc_project::Common::Callout::Error::GPIO>
-{
-    using type = xyz::openbmc_project::Common::Callout::GPIO;
-};
-
-} // namespace details
-
-namespace xyz
-{
-namespace openbmc_project
-{
-namespace Common
-{
-namespace Callout
-{
-namespace _IIC
-{
-
-struct CALLOUT_IIC_BUS
-{
-    /*
-     * We can't use -fsanitize=undefined if we declare a
-     * 'static constexpr auto str' member, so don't. Instead, open-code the
-     * mako template lookups.
-     */
-    static constexpr auto str_short = "CALLOUT_IIC_BUS";
-    using type =
-        std::tuple<std::decay_t<decltype("CALLOUT_IIC_BUS=%s")>, const char*>;
-    explicit constexpr CALLOUT_IIC_BUS(const char* a) :
-        _entry(entry("CALLOUT_IIC_BUS=%s", a)){};
-    type _entry;
-};
-struct CALLOUT_IIC_ADDR
-{
-    /*
-     * We can't use -fsanitize=undefined if we declare a
-     * 'static constexpr auto str' member, so don't. Instead, open-code the
-     * mako template lookups.
-     */
-    static constexpr auto str_short = "CALLOUT_IIC_ADDR";
-    using type =
-        std::tuple<std::decay_t<decltype("CALLOUT_IIC_ADDR=0x%hx")>, uint16_t>;
-    explicit constexpr CALLOUT_IIC_ADDR(uint16_t a) :
-        _entry(entry("CALLOUT_IIC_ADDR=0x%hx", a)){};
-    type _entry;
-};
-
-} // namespace _IIC
-
-struct IIC
-{
-    static constexpr auto L = level::ERR;
-    using CALLOUT_IIC_BUS = _IIC::CALLOUT_IIC_BUS;
-    using CALLOUT_IIC_ADDR = _IIC::CALLOUT_IIC_ADDR;
-    using CALLOUT_ERRNO =
-        xyz::openbmc_project::Common::Callout::Device::CALLOUT_ERRNO;
-    using CALLOUT_DEVICE_PATH =
-        xyz::openbmc_project::Common::Callout::Device::CALLOUT_DEVICE_PATH;
-    using metadata_types = std::tuple<CALLOUT_IIC_BUS, CALLOUT_IIC_ADDR,
-                                      CALLOUT_ERRNO, CALLOUT_DEVICE_PATH>;
-};
-
-} // namespace Callout
-} // namespace Common
-} // namespace openbmc_project
-} // namespace xyz
-
-namespace details
-{
-
-template <>
-struct map_exception_type<
-    sdbusplus::xyz::openbmc_project::Common::Callout::Error::IIC>
-{
-    using type = xyz::openbmc_project::Common::Callout::IIC;
-};
-
-} // namespace details
-
-namespace xyz
-{
-namespace openbmc_project
-{
-namespace Common
-{
-namespace Callout
-{
-namespace _Inventory
-{
-
-struct CALLOUT_INVENTORY_PATH
-{
-    /*
-     * We can't use -fsanitize=undefined if we declare a
-     * 'static constexpr auto str' member, so don't. Instead, open-code the
-     * mako template lookups.
-     */
-    static constexpr auto str_short = "CALLOUT_INVENTORY_PATH";
-    using type = std::tuple<std::decay_t<decltype("CALLOUT_INVENTORY_PATH=%s")>,
-                            const char*>;
-    explicit constexpr CALLOUT_INVENTORY_PATH(const char* a) :
-        _entry(entry("CALLOUT_INVENTORY_PATH=%s", a)){};
-    type _entry;
-};
-
-} // namespace _Inventory
-
-struct Inventory
-{
-    static constexpr auto L = level::ERR;
-    using CALLOUT_INVENTORY_PATH = _Inventory::CALLOUT_INVENTORY_PATH;
-    using metadata_types = std::tuple<CALLOUT_INVENTORY_PATH>;
-};
-
-} // namespace Callout
-} // namespace Common
-} // namespace openbmc_project
-} // namespace xyz
-
-namespace details
-{
-
-template <>
-struct map_exception_type<
-    sdbusplus::xyz::openbmc_project::Common::Callout::Error::Inventory>
-{
-    using type = xyz::openbmc_project::Common::Callout::Inventory;
-};
-
-} // namespace details
-
-namespace xyz
-{
-namespace openbmc_project
-{
-namespace Common
-{
-namespace Callout
-{
-namespace _IPMISensor
-{
-
-struct CALLOUT_IPMI_SENSOR_NUM
-{
-    /*
-     * We can't use -fsanitize=undefined if we declare a
-     * 'static constexpr auto str' member, so don't. Instead, open-code the
-     * mako template lookups.
-     */
-    static constexpr auto str_short = "CALLOUT_IPMI_SENSOR_NUM";
-    using type =
-        std::tuple<std::decay_t<decltype("CALLOUT_IPMI_SENSOR_NUM=%u")>,
-                   uint32_t>;
-    explicit constexpr CALLOUT_IPMI_SENSOR_NUM(uint32_t a) :
-        _entry(entry("CALLOUT_IPMI_SENSOR_NUM=%u", a)){};
-    type _entry;
-};
-
-} // namespace _IPMISensor
-
-struct IPMISensor
-{
-    static constexpr auto L = level::ERR;
-    using CALLOUT_IPMI_SENSOR_NUM = _IPMISensor::CALLOUT_IPMI_SENSOR_NUM;
-    using metadata_types = std::tuple<CALLOUT_IPMI_SENSOR_NUM>;
-};
-
-} // namespace Callout
-} // namespace Common
-} // namespace openbmc_project
-} // namespace xyz
-
-namespace details
-{
-
-template <>
-struct map_exception_type<
-    sdbusplus::xyz::openbmc_project::Common::Callout::Error::IPMISensor>
-{
-    using type = xyz::openbmc_project::Common::Callout::IPMISensor;
-};
-
-} // namespace details
-
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace _PowerSupplyInputFault
-{
-
-struct RAW_STATUS
-{
-    /*
-     * We can't use -fsanitize=undefined if we declare a
-     * 'static constexpr auto str' member, so don't. Instead, open-code the
-     * mako template lookups.
-     */
-    static constexpr auto str_short = "RAW_STATUS";
-    using type =
-        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
-    explicit constexpr RAW_STATUS(const char* a) :
-        _entry(entry("RAW_STATUS=%s", a)){};
-    type _entry;
-};
-
-} // namespace _PowerSupplyInputFault
-
-struct PowerSupplyInputFault
-{
-    static constexpr auto L = level::ERR;
-    using RAW_STATUS = _PowerSupplyInputFault::RAW_STATUS;
-    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::
-        Inventory::CALLOUT_INVENTORY_PATH;
-    using metadata_types = std::tuple<RAW_STATUS, CALLOUT_INVENTORY_PATH>;
-};
-
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-
-namespace details
-{
-
-template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
-                              Error::PowerSupplyInputFault>
-{
-    using type = org::open_power::Witherspoon::Fault::PowerSupplyInputFault;
-};
-
-} // namespace details
-
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace _PowerSupplyShouldBeOn
-{
-
-struct RAW_STATUS
-{
-    /*
-     * We can't use -fsanitize=undefined if we declare a
-     * 'static constexpr auto str' member, so don't. Instead, open-code the
-     * mako template lookups.
-     */
-    static constexpr auto str_short = "RAW_STATUS";
-    using type =
-        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
-    explicit constexpr RAW_STATUS(const char* a) :
-        _entry(entry("RAW_STATUS=%s", a)){};
-    type _entry;
-};
-
-} // namespace _PowerSupplyShouldBeOn
-
-struct PowerSupplyShouldBeOn
-{
-    static constexpr auto L = level::ERR;
-    using RAW_STATUS = _PowerSupplyShouldBeOn::RAW_STATUS;
-    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::
-        Inventory::CALLOUT_INVENTORY_PATH;
-    using metadata_types = std::tuple<RAW_STATUS, CALLOUT_INVENTORY_PATH>;
-};
-
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-
-namespace details
-{
-
-template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
-                              Error::PowerSupplyShouldBeOn>
-{
-    using type = org::open_power::Witherspoon::Fault::PowerSupplyShouldBeOn;
-};
-
-} // namespace details
-
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace _PowerSupplyOutputOvercurrent
-{
-
-struct RAW_STATUS
-{
-    /*
-     * We can't use -fsanitize=undefined if we declare a
-     * 'static constexpr auto str' member, so don't. Instead, open-code the
-     * mako template lookups.
-     */
-    static constexpr auto str_short = "RAW_STATUS";
-    using type =
-        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
-    explicit constexpr RAW_STATUS(const char* a) :
-        _entry(entry("RAW_STATUS=%s", a)){};
-    type _entry;
-};
-
-} // namespace _PowerSupplyOutputOvercurrent
-
-struct PowerSupplyOutputOvercurrent
-{
-    static constexpr auto L = level::ERR;
-    using RAW_STATUS = _PowerSupplyOutputOvercurrent::RAW_STATUS;
-    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::
-        Inventory::CALLOUT_INVENTORY_PATH;
-    using metadata_types = std::tuple<RAW_STATUS, CALLOUT_INVENTORY_PATH>;
-};
-
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-
-namespace details
-{
-
-template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
-                              Error::PowerSupplyOutputOvercurrent>
-{
-    using type =
-        org::open_power::Witherspoon::Fault::PowerSupplyOutputOvercurrent;
-};
-
-} // namespace details
-
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace _PowerSupplyOutputOvervoltage
-{
-
-struct RAW_STATUS
-{
-    /*
-     * We can't use -fsanitize=undefined if we declare a
-     * 'static constexpr auto str' member, so don't. Instead, open-code the
-     * mako template lookups.
-     */
-    static constexpr auto str_short = "RAW_STATUS";
-    using type =
-        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
-    explicit constexpr RAW_STATUS(const char* a) :
-        _entry(entry("RAW_STATUS=%s", a)){};
-    type _entry;
-};
-
-} // namespace _PowerSupplyOutputOvervoltage
-
-struct PowerSupplyOutputOvervoltage
-{
-    static constexpr auto L = level::ERR;
-    using RAW_STATUS = _PowerSupplyOutputOvervoltage::RAW_STATUS;
-    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::
-        Inventory::CALLOUT_INVENTORY_PATH;
-    using metadata_types = std::tuple<RAW_STATUS, CALLOUT_INVENTORY_PATH>;
-};
-
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-
-namespace details
-{
-
-template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
-                              Error::PowerSupplyOutputOvervoltage>
-{
-    using type =
-        org::open_power::Witherspoon::Fault::PowerSupplyOutputOvervoltage;
-};
-
-} // namespace details
-
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace _PowerSupplyFanFault
-{
-
-struct RAW_STATUS
-{
-    /*
-     * We can't use -fsanitize=undefined if we declare a
-     * 'static constexpr auto str' member, so don't. Instead, open-code the
-     * mako template lookups.
-     */
-    static constexpr auto str_short = "RAW_STATUS";
-    using type =
-        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
-    explicit constexpr RAW_STATUS(const char* a) :
-        _entry(entry("RAW_STATUS=%s", a)){};
-    type _entry;
-};
-
-} // namespace _PowerSupplyFanFault
-
-struct PowerSupplyFanFault
-{
-    static constexpr auto L = level::ERR;
-    using RAW_STATUS = _PowerSupplyFanFault::RAW_STATUS;
-    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::
-        Inventory::CALLOUT_INVENTORY_PATH;
-    using metadata_types = std::tuple<RAW_STATUS, CALLOUT_INVENTORY_PATH>;
-};
-
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-
-namespace details
-{
-
-template <>
-struct map_exception_type<
-    sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerSupplyFanFault>
-{
-    using type = org::open_power::Witherspoon::Fault::PowerSupplyFanFault;
-};
-
-} // namespace details
-
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace _PowerSupplyTemperatureFault
-{
-
-struct RAW_STATUS
-{
-    /*
-     * We can't use -fsanitize=undefined if we declare a
-     * 'static constexpr auto str' member, so don't. Instead, open-code the
-     * mako template lookups.
-     */
-    static constexpr auto str_short = "RAW_STATUS";
-    using type =
-        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
-    explicit constexpr RAW_STATUS(const char* a) :
-        _entry(entry("RAW_STATUS=%s", a)){};
-    type _entry;
-};
-
-} // namespace _PowerSupplyTemperatureFault
-
-struct PowerSupplyTemperatureFault
-{
-    static constexpr auto L = level::ERR;
-    using RAW_STATUS = _PowerSupplyTemperatureFault::RAW_STATUS;
-    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::
-        Inventory::CALLOUT_INVENTORY_PATH;
-    using metadata_types = std::tuple<RAW_STATUS, CALLOUT_INVENTORY_PATH>;
-};
-
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-
-namespace details
-{
-
-template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
-                              Error::PowerSupplyTemperatureFault>
-{
-    using type =
-        org::open_power::Witherspoon::Fault::PowerSupplyTemperatureFault;
-};
-
-} // namespace details
 
 namespace org
 {
@@ -1034,12 +1167,14 @@ namespace Fault
 namespace _Shutdown
 {
 
-} // namespace _Shutdown
+
+}  // namespace _Shutdown
 
 struct Shutdown
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
+
 };
 
 } // namespace Fault
@@ -1047,17 +1182,17 @@ struct Shutdown
 } // namespace open_power
 } // namespace org
 
+
 namespace details
 {
 
 template <>
-struct map_exception_type<
-    sdbusplus::org::open_power::Witherspoon::Fault::Error::Shutdown>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::Shutdown>
 {
     using type = org::open_power::Witherspoon::Fault::Shutdown;
 };
 
-} // namespace details
+}
 
 namespace org
 {
@@ -1070,12 +1205,14 @@ namespace Fault
 namespace _PowerOnFailure
 {
 
-} // namespace _PowerOnFailure
+
+}  // namespace _PowerOnFailure
 
 struct PowerOnFailure
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
+
 };
 
 } // namespace Fault
@@ -1083,17 +1220,1461 @@ struct PowerOnFailure
 } // namespace open_power
 } // namespace org
 
+
 namespace details
 {
 
 template <>
-struct map_exception_type<
-    sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnFailure>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnFailure>
 {
     using type = org::open_power::Witherspoon::Fault::PowerOnFailure;
 };
 
-} // namespace details
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PSUPresentError
+{
+
+
+}  // namespace _PSUPresentError
+
+struct PSUPresentError
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PSUPresentError>
+{
+    using type = org::open_power::Witherspoon::Fault::PSUPresentError;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode1
+{
+
+
+}  // namespace _PowerOnErrorCode1
+
+struct PowerOnErrorCode1
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode1>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode1;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode2
+{
+
+
+}  // namespace _PowerOnErrorCode2
+
+struct PowerOnErrorCode2
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode2>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode2;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode3
+{
+
+
+}  // namespace _PowerOnErrorCode3
+
+struct PowerOnErrorCode3
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode3>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode3;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode4
+{
+
+
+}  // namespace _PowerOnErrorCode4
+
+struct PowerOnErrorCode4
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode4>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode4;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode5
+{
+
+
+}  // namespace _PowerOnErrorCode5
+
+struct PowerOnErrorCode5
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode5>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode5;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode6
+{
+
+
+}  // namespace _PowerOnErrorCode6
+
+struct PowerOnErrorCode6
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode6>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode6;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode7
+{
+
+
+}  // namespace _PowerOnErrorCode7
+
+struct PowerOnErrorCode7
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode7>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode7;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode8
+{
+
+
+}  // namespace _PowerOnErrorCode8
+
+struct PowerOnErrorCode8
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode8>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode8;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode9
+{
+
+
+}  // namespace _PowerOnErrorCode9
+
+struct PowerOnErrorCode9
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode9>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode9;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode10
+{
+
+
+}  // namespace _PowerOnErrorCode10
+
+struct PowerOnErrorCode10
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode10>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode10;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode11
+{
+
+
+}  // namespace _PowerOnErrorCode11
+
+struct PowerOnErrorCode11
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode11>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode11;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode12
+{
+
+
+}  // namespace _PowerOnErrorCode12
+
+struct PowerOnErrorCode12
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode12>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode12;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode13
+{
+
+
+}  // namespace _PowerOnErrorCode13
+
+struct PowerOnErrorCode13
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode13>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode13;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode14
+{
+
+
+}  // namespace _PowerOnErrorCode14
+
+struct PowerOnErrorCode14
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode14>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode14;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode15
+{
+
+
+}  // namespace _PowerOnErrorCode15
+
+struct PowerOnErrorCode15
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode15>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode15;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode16
+{
+
+
+}  // namespace _PowerOnErrorCode16
+
+struct PowerOnErrorCode16
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode16>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode16;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode17
+{
+
+
+}  // namespace _PowerOnErrorCode17
+
+struct PowerOnErrorCode17
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode17>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode17;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode18
+{
+
+
+}  // namespace _PowerOnErrorCode18
+
+struct PowerOnErrorCode18
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode18>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode18;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode19
+{
+
+
+}  // namespace _PowerOnErrorCode19
+
+struct PowerOnErrorCode19
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode19>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode19;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode20
+{
+
+
+}  // namespace _PowerOnErrorCode20
+
+struct PowerOnErrorCode20
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode20>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode20;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode21
+{
+
+
+}  // namespace _PowerOnErrorCode21
+
+struct PowerOnErrorCode21
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode21>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode21;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode22
+{
+
+
+}  // namespace _PowerOnErrorCode22
+
+struct PowerOnErrorCode22
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode22>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode22;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode23
+{
+
+
+}  // namespace _PowerOnErrorCode23
+
+struct PowerOnErrorCode23
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode23>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode23;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode24
+{
+
+
+}  // namespace _PowerOnErrorCode24
+
+struct PowerOnErrorCode24
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode24>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode24;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode25
+{
+
+
+}  // namespace _PowerOnErrorCode25
+
+struct PowerOnErrorCode25
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode25>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode25;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode26
+{
+
+
+}  // namespace _PowerOnErrorCode26
+
+struct PowerOnErrorCode26
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode26>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode26;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode27
+{
+
+
+}  // namespace _PowerOnErrorCode27
+
+struct PowerOnErrorCode27
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode27>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode27;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode28
+{
+
+
+}  // namespace _PowerOnErrorCode28
+
+struct PowerOnErrorCode28
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode28>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode28;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode29
+{
+
+
+}  // namespace _PowerOnErrorCode29
+
+struct PowerOnErrorCode29
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode29>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode29;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode30
+{
+
+
+}  // namespace _PowerOnErrorCode30
+
+struct PowerOnErrorCode30
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode30>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode30;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode31
+{
+
+
+}  // namespace _PowerOnErrorCode31
+
+struct PowerOnErrorCode31
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode31>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode31;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode32
+{
+
+
+}  // namespace _PowerOnErrorCode32
+
+struct PowerOnErrorCode32
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode32>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode32;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode33
+{
+
+
+}  // namespace _PowerOnErrorCode33
+
+struct PowerOnErrorCode33
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode33>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode33;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode34
+{
+
+
+}  // namespace _PowerOnErrorCode34
+
+struct PowerOnErrorCode34
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode34>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode34;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode35
+{
+
+
+}  // namespace _PowerOnErrorCode35
+
+struct PowerOnErrorCode35
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode35>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode35;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode36
+{
+
+
+}  // namespace _PowerOnErrorCode36
+
+struct PowerOnErrorCode36
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode36>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode36;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode0
+{
+
+
+}  // namespace _PowerOnErrorCode0
+
+struct PowerOnErrorCode0
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode0>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode0;
+};
+
+}
 
 namespace org
 {
@@ -1114,8 +2695,8 @@ struct RAIL
      * mako template lookups.
      */
     static constexpr auto str_short = "RAIL";
-    using type = std::tuple<std::decay_t<decltype("RAIL=%d")>, uint16_t>;
-    explicit constexpr RAIL(uint16_t a) : _entry(entry("RAIL=%d", a)){};
+    using type = std::tuple<std::decay_t<decltype("RAIL=%d")>,uint16_t>;
+    explicit constexpr RAIL(uint16_t a) : _entry(entry("RAIL=%d", a)) {};
     type _entry;
 };
 struct RAIL_NAME
@@ -1126,10 +2707,8 @@ struct RAIL_NAME
      * mako template lookups.
      */
     static constexpr auto str_short = "RAIL_NAME";
-    using type =
-        std::tuple<std::decay_t<decltype("RAIL_NAME=%s")>, const char*>;
-    explicit constexpr RAIL_NAME(const char* a) :
-        _entry(entry("RAIL_NAME=%s", a)){};
+    using type = std::tuple<std::decay_t<decltype("RAIL_NAME=%s")>,const char*>;
+    explicit constexpr RAIL_NAME(const char* a) : _entry(entry("RAIL_NAME=%s", a)) {};
     type _entry;
 };
 struct RAW_STATUS
@@ -1140,14 +2719,12 @@ struct RAW_STATUS
      * mako template lookups.
      */
     static constexpr auto str_short = "RAW_STATUS";
-    using type =
-        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
-    explicit constexpr RAW_STATUS(const char* a) :
-        _entry(entry("RAW_STATUS=%s", a)){};
+    using type = std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>,const char*>;
+    explicit constexpr RAW_STATUS(const char* a) : _entry(entry("RAW_STATUS=%s", a)) {};
     type _entry;
 };
 
-} // namespace _PowerSequencerVoltageFault
+}  // namespace _PowerSequencerVoltageFault
 
 struct PowerSequencerVoltageFault
 {
@@ -1156,6 +2733,7 @@ struct PowerSequencerVoltageFault
     using RAIL_NAME = _PowerSequencerVoltageFault::RAIL_NAME;
     using RAW_STATUS = _PowerSequencerVoltageFault::RAW_STATUS;
     using metadata_types = std::tuple<RAIL, RAIL_NAME, RAW_STATUS>;
+
 };
 
 } // namespace Fault
@@ -1163,18 +2741,17 @@ struct PowerSequencerVoltageFault
 } // namespace open_power
 } // namespace org
 
+
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
-                              Error::PowerSequencerVoltageFault>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerSequencerVoltageFault>
 {
-    using type =
-        org::open_power::Witherspoon::Fault::PowerSequencerVoltageFault;
+    using type = org::open_power::Witherspoon::Fault::PowerSequencerVoltageFault;
 };
 
-} // namespace details
+}
 
 namespace org
 {
@@ -1195,9 +2772,8 @@ struct INPUT_NUM
      * mako template lookups.
      */
     static constexpr auto str_short = "INPUT_NUM";
-    using type = std::tuple<std::decay_t<decltype("INPUT_NUM=%d")>, uint16_t>;
-    explicit constexpr INPUT_NUM(uint16_t a) :
-        _entry(entry("INPUT_NUM=%d", a)){};
+    using type = std::tuple<std::decay_t<decltype("INPUT_NUM=%d")>,uint16_t>;
+    explicit constexpr INPUT_NUM(uint16_t a) : _entry(entry("INPUT_NUM=%d", a)) {};
     type _entry;
 };
 struct INPUT_NAME
@@ -1208,10 +2784,8 @@ struct INPUT_NAME
      * mako template lookups.
      */
     static constexpr auto str_short = "INPUT_NAME";
-    using type =
-        std::tuple<std::decay_t<decltype("INPUT_NAME=%s")>, const char*>;
-    explicit constexpr INPUT_NAME(const char* a) :
-        _entry(entry("INPUT_NAME=%s", a)){};
+    using type = std::tuple<std::decay_t<decltype("INPUT_NAME=%s")>,const char*>;
+    explicit constexpr INPUT_NAME(const char* a) : _entry(entry("INPUT_NAME=%s", a)) {};
     type _entry;
 };
 struct RAW_STATUS
@@ -1222,14 +2796,12 @@ struct RAW_STATUS
      * mako template lookups.
      */
     static constexpr auto str_short = "RAW_STATUS";
-    using type =
-        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
-    explicit constexpr RAW_STATUS(const char* a) :
-        _entry(entry("RAW_STATUS=%s", a)){};
+    using type = std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>,const char*>;
+    explicit constexpr RAW_STATUS(const char* a) : _entry(entry("RAW_STATUS=%s", a)) {};
     type _entry;
 };
 
-} // namespace _PowerSequencerPGOODFault
+}  // namespace _PowerSequencerPGOODFault
 
 struct PowerSequencerPGOODFault
 {
@@ -1238,6 +2810,7 @@ struct PowerSequencerPGOODFault
     using INPUT_NAME = _PowerSequencerPGOODFault::INPUT_NAME;
     using RAW_STATUS = _PowerSequencerPGOODFault::RAW_STATUS;
     using metadata_types = std::tuple<INPUT_NUM, INPUT_NAME, RAW_STATUS>;
+
 };
 
 } // namespace Fault
@@ -1245,17 +2818,17 @@ struct PowerSequencerPGOODFault
 } // namespace open_power
 } // namespace org
 
+
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
-                              Error::PowerSequencerPGOODFault>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerSequencerPGOODFault>
 {
     using type = org::open_power::Witherspoon::Fault::PowerSequencerPGOODFault;
 };
 
-} // namespace details
+}
 
 namespace org
 {
@@ -1276,20 +2849,19 @@ struct RAW_STATUS
      * mako template lookups.
      */
     static constexpr auto str_short = "RAW_STATUS";
-    using type =
-        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
-    explicit constexpr RAW_STATUS(const char* a) :
-        _entry(entry("RAW_STATUS=%s", a)){};
+    using type = std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>,const char*>;
+    explicit constexpr RAW_STATUS(const char* a) : _entry(entry("RAW_STATUS=%s", a)) {};
     type _entry;
 };
 
-} // namespace _PowerSequencerFault
+}  // namespace _PowerSequencerFault
 
 struct PowerSequencerFault
 {
     static constexpr auto L = level::ERR;
     using RAW_STATUS = _PowerSequencerFault::RAW_STATUS;
     using metadata_types = std::tuple<RAW_STATUS>;
+
 };
 
 } // namespace Fault
@@ -1297,17 +2869,614 @@ struct PowerSequencerFault
 } // namespace open_power
 } // namespace org
 
+
 namespace details
 {
 
 template <>
-struct map_exception_type<
-    sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerSequencerFault>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerSequencerFault>
 {
     using type = org::open_power::Witherspoon::Fault::PowerSequencerFault;
 };
 
-} // namespace details
+}
+
+namespace xyz
+{
+namespace openbmc_project
+{
+namespace Common
+{
+namespace Callout
+{
+namespace _Device
+{
+
+struct CALLOUT_ERRNO
+{
+    /*
+     * We can't use -fsanitize=undefined if we declare a
+     * 'static constexpr auto str' member, so don't. Instead, open-code the
+     * mako template lookups.
+     */
+    static constexpr auto str_short = "CALLOUT_ERRNO";
+    using type = std::tuple<std::decay_t<decltype("CALLOUT_ERRNO=%d")>,int32_t>;
+    explicit constexpr CALLOUT_ERRNO(int32_t a) : _entry(entry("CALLOUT_ERRNO=%d", a)) {};
+    type _entry;
+};
+struct CALLOUT_DEVICE_PATH
+{
+    /*
+     * We can't use -fsanitize=undefined if we declare a
+     * 'static constexpr auto str' member, so don't. Instead, open-code the
+     * mako template lookups.
+     */
+    static constexpr auto str_short = "CALLOUT_DEVICE_PATH";
+    using type = std::tuple<std::decay_t<decltype("CALLOUT_DEVICE_PATH=%s")>,const char*>;
+    explicit constexpr CALLOUT_DEVICE_PATH(const char* a) : _entry(entry("CALLOUT_DEVICE_PATH=%s", a)) {};
+    type _entry;
+};
+
+}  // namespace _Device
+
+struct Device
+{
+    static constexpr auto L = level::ERR;
+    using CALLOUT_ERRNO = _Device::CALLOUT_ERRNO;
+    using CALLOUT_DEVICE_PATH = _Device::CALLOUT_DEVICE_PATH;
+    using metadata_types = std::tuple<CALLOUT_ERRNO, CALLOUT_DEVICE_PATH>;
+
+};
+
+} // namespace Callout
+} // namespace Common
+} // namespace openbmc_project
+} // namespace xyz
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::xyz::openbmc_project::Common::Callout::Error::Device>
+{
+    using type = xyz::openbmc_project::Common::Callout::Device;
+};
+
+}
+
+namespace xyz
+{
+namespace openbmc_project
+{
+namespace Common
+{
+namespace Callout
+{
+namespace _GPIO
+{
+
+struct CALLOUT_GPIO_NUM
+{
+    /*
+     * We can't use -fsanitize=undefined if we declare a
+     * 'static constexpr auto str' member, so don't. Instead, open-code the
+     * mako template lookups.
+     */
+    static constexpr auto str_short = "CALLOUT_GPIO_NUM";
+    using type = std::tuple<std::decay_t<decltype("CALLOUT_GPIO_NUM=%u")>,uint32_t>;
+    explicit constexpr CALLOUT_GPIO_NUM(uint32_t a) : _entry(entry("CALLOUT_GPIO_NUM=%u", a)) {};
+    type _entry;
+};
+
+}  // namespace _GPIO
+
+struct GPIO
+{
+    static constexpr auto L = level::ERR;
+    using CALLOUT_GPIO_NUM = _GPIO::CALLOUT_GPIO_NUM;
+    using CALLOUT_ERRNO = xyz::openbmc_project::Common::Callout::Device::CALLOUT_ERRNO;
+    using CALLOUT_DEVICE_PATH = xyz::openbmc_project::Common::Callout::Device::CALLOUT_DEVICE_PATH;
+    using metadata_types = std::tuple<CALLOUT_GPIO_NUM, CALLOUT_ERRNO, CALLOUT_DEVICE_PATH>;
+
+};
+
+} // namespace Callout
+} // namespace Common
+} // namespace openbmc_project
+} // namespace xyz
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::xyz::openbmc_project::Common::Callout::Error::GPIO>
+{
+    using type = xyz::openbmc_project::Common::Callout::GPIO;
+};
+
+}
+
+namespace xyz
+{
+namespace openbmc_project
+{
+namespace Common
+{
+namespace Callout
+{
+namespace _IIC
+{
+
+struct CALLOUT_IIC_BUS
+{
+    /*
+     * We can't use -fsanitize=undefined if we declare a
+     * 'static constexpr auto str' member, so don't. Instead, open-code the
+     * mako template lookups.
+     */
+    static constexpr auto str_short = "CALLOUT_IIC_BUS";
+    using type = std::tuple<std::decay_t<decltype("CALLOUT_IIC_BUS=%s")>,const char*>;
+    explicit constexpr CALLOUT_IIC_BUS(const char* a) : _entry(entry("CALLOUT_IIC_BUS=%s", a)) {};
+    type _entry;
+};
+struct CALLOUT_IIC_ADDR
+{
+    /*
+     * We can't use -fsanitize=undefined if we declare a
+     * 'static constexpr auto str' member, so don't. Instead, open-code the
+     * mako template lookups.
+     */
+    static constexpr auto str_short = "CALLOUT_IIC_ADDR";
+    using type = std::tuple<std::decay_t<decltype("CALLOUT_IIC_ADDR=0x%hx")>,uint16_t>;
+    explicit constexpr CALLOUT_IIC_ADDR(uint16_t a) : _entry(entry("CALLOUT_IIC_ADDR=0x%hx", a)) {};
+    type _entry;
+};
+
+}  // namespace _IIC
+
+struct IIC
+{
+    static constexpr auto L = level::ERR;
+    using CALLOUT_IIC_BUS = _IIC::CALLOUT_IIC_BUS;
+    using CALLOUT_IIC_ADDR = _IIC::CALLOUT_IIC_ADDR;
+    using CALLOUT_ERRNO = xyz::openbmc_project::Common::Callout::Device::CALLOUT_ERRNO;
+    using CALLOUT_DEVICE_PATH = xyz::openbmc_project::Common::Callout::Device::CALLOUT_DEVICE_PATH;
+    using metadata_types = std::tuple<CALLOUT_IIC_BUS, CALLOUT_IIC_ADDR, CALLOUT_ERRNO, CALLOUT_DEVICE_PATH>;
+
+};
+
+} // namespace Callout
+} // namespace Common
+} // namespace openbmc_project
+} // namespace xyz
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::xyz::openbmc_project::Common::Callout::Error::IIC>
+{
+    using type = xyz::openbmc_project::Common::Callout::IIC;
+};
+
+}
+
+namespace xyz
+{
+namespace openbmc_project
+{
+namespace Common
+{
+namespace Callout
+{
+namespace _Inventory
+{
+
+struct CALLOUT_INVENTORY_PATH
+{
+    /*
+     * We can't use -fsanitize=undefined if we declare a
+     * 'static constexpr auto str' member, so don't. Instead, open-code the
+     * mako template lookups.
+     */
+    static constexpr auto str_short = "CALLOUT_INVENTORY_PATH";
+    using type = std::tuple<std::decay_t<decltype("CALLOUT_INVENTORY_PATH=%s")>,const char*>;
+    explicit constexpr CALLOUT_INVENTORY_PATH(const char* a) : _entry(entry("CALLOUT_INVENTORY_PATH=%s", a)) {};
+    type _entry;
+};
+
+}  // namespace _Inventory
+
+struct Inventory
+{
+    static constexpr auto L = level::ERR;
+    using CALLOUT_INVENTORY_PATH = _Inventory::CALLOUT_INVENTORY_PATH;
+    using metadata_types = std::tuple<CALLOUT_INVENTORY_PATH>;
+
+};
+
+} // namespace Callout
+} // namespace Common
+} // namespace openbmc_project
+} // namespace xyz
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::xyz::openbmc_project::Common::Callout::Error::Inventory>
+{
+    using type = xyz::openbmc_project::Common::Callout::Inventory;
+};
+
+}
+
+namespace xyz
+{
+namespace openbmc_project
+{
+namespace Common
+{
+namespace Callout
+{
+namespace _IPMISensor
+{
+
+struct CALLOUT_IPMI_SENSOR_NUM
+{
+    /*
+     * We can't use -fsanitize=undefined if we declare a
+     * 'static constexpr auto str' member, so don't. Instead, open-code the
+     * mako template lookups.
+     */
+    static constexpr auto str_short = "CALLOUT_IPMI_SENSOR_NUM";
+    using type = std::tuple<std::decay_t<decltype("CALLOUT_IPMI_SENSOR_NUM=%u")>,uint32_t>;
+    explicit constexpr CALLOUT_IPMI_SENSOR_NUM(uint32_t a) : _entry(entry("CALLOUT_IPMI_SENSOR_NUM=%u", a)) {};
+    type _entry;
+};
+
+}  // namespace _IPMISensor
+
+struct IPMISensor
+{
+    static constexpr auto L = level::ERR;
+    using CALLOUT_IPMI_SENSOR_NUM = _IPMISensor::CALLOUT_IPMI_SENSOR_NUM;
+    using metadata_types = std::tuple<CALLOUT_IPMI_SENSOR_NUM>;
+
+};
+
+} // namespace Callout
+} // namespace Common
+} // namespace openbmc_project
+} // namespace xyz
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::xyz::openbmc_project::Common::Callout::Error::IPMISensor>
+{
+    using type = xyz::openbmc_project::Common::Callout::IPMISensor;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerSupplyInputFault
+{
+
+struct RAW_STATUS
+{
+    /*
+     * We can't use -fsanitize=undefined if we declare a
+     * 'static constexpr auto str' member, so don't. Instead, open-code the
+     * mako template lookups.
+     */
+    static constexpr auto str_short = "RAW_STATUS";
+    using type = std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>,const char*>;
+    explicit constexpr RAW_STATUS(const char* a) : _entry(entry("RAW_STATUS=%s", a)) {};
+    type _entry;
+};
+
+}  // namespace _PowerSupplyInputFault
+
+struct PowerSupplyInputFault
+{
+    static constexpr auto L = level::ERR;
+    using RAW_STATUS = _PowerSupplyInputFault::RAW_STATUS;
+    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::Inventory::CALLOUT_INVENTORY_PATH;
+    using metadata_types = std::tuple<RAW_STATUS, CALLOUT_INVENTORY_PATH>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerSupplyInputFault>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerSupplyInputFault;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerSupplyShouldBeOn
+{
+
+struct RAW_STATUS
+{
+    /*
+     * We can't use -fsanitize=undefined if we declare a
+     * 'static constexpr auto str' member, so don't. Instead, open-code the
+     * mako template lookups.
+     */
+    static constexpr auto str_short = "RAW_STATUS";
+    using type = std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>,const char*>;
+    explicit constexpr RAW_STATUS(const char* a) : _entry(entry("RAW_STATUS=%s", a)) {};
+    type _entry;
+};
+
+}  // namespace _PowerSupplyShouldBeOn
+
+struct PowerSupplyShouldBeOn
+{
+    static constexpr auto L = level::ERR;
+    using RAW_STATUS = _PowerSupplyShouldBeOn::RAW_STATUS;
+    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::Inventory::CALLOUT_INVENTORY_PATH;
+    using metadata_types = std::tuple<RAW_STATUS, CALLOUT_INVENTORY_PATH>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerSupplyShouldBeOn>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerSupplyShouldBeOn;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerSupplyOutputOvercurrent
+{
+
+struct RAW_STATUS
+{
+    /*
+     * We can't use -fsanitize=undefined if we declare a
+     * 'static constexpr auto str' member, so don't. Instead, open-code the
+     * mako template lookups.
+     */
+    static constexpr auto str_short = "RAW_STATUS";
+    using type = std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>,const char*>;
+    explicit constexpr RAW_STATUS(const char* a) : _entry(entry("RAW_STATUS=%s", a)) {};
+    type _entry;
+};
+
+}  // namespace _PowerSupplyOutputOvercurrent
+
+struct PowerSupplyOutputOvercurrent
+{
+    static constexpr auto L = level::ERR;
+    using RAW_STATUS = _PowerSupplyOutputOvercurrent::RAW_STATUS;
+    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::Inventory::CALLOUT_INVENTORY_PATH;
+    using metadata_types = std::tuple<RAW_STATUS, CALLOUT_INVENTORY_PATH>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerSupplyOutputOvercurrent>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerSupplyOutputOvercurrent;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerSupplyOutputOvervoltage
+{
+
+struct RAW_STATUS
+{
+    /*
+     * We can't use -fsanitize=undefined if we declare a
+     * 'static constexpr auto str' member, so don't. Instead, open-code the
+     * mako template lookups.
+     */
+    static constexpr auto str_short = "RAW_STATUS";
+    using type = std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>,const char*>;
+    explicit constexpr RAW_STATUS(const char* a) : _entry(entry("RAW_STATUS=%s", a)) {};
+    type _entry;
+};
+
+}  // namespace _PowerSupplyOutputOvervoltage
+
+struct PowerSupplyOutputOvervoltage
+{
+    static constexpr auto L = level::ERR;
+    using RAW_STATUS = _PowerSupplyOutputOvervoltage::RAW_STATUS;
+    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::Inventory::CALLOUT_INVENTORY_PATH;
+    using metadata_types = std::tuple<RAW_STATUS, CALLOUT_INVENTORY_PATH>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerSupplyOutputOvervoltage>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerSupplyOutputOvervoltage;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerSupplyFanFault
+{
+
+struct RAW_STATUS
+{
+    /*
+     * We can't use -fsanitize=undefined if we declare a
+     * 'static constexpr auto str' member, so don't. Instead, open-code the
+     * mako template lookups.
+     */
+    static constexpr auto str_short = "RAW_STATUS";
+    using type = std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>,const char*>;
+    explicit constexpr RAW_STATUS(const char* a) : _entry(entry("RAW_STATUS=%s", a)) {};
+    type _entry;
+};
+
+}  // namespace _PowerSupplyFanFault
+
+struct PowerSupplyFanFault
+{
+    static constexpr auto L = level::ERR;
+    using RAW_STATUS = _PowerSupplyFanFault::RAW_STATUS;
+    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::Inventory::CALLOUT_INVENTORY_PATH;
+    using metadata_types = std::tuple<RAW_STATUS, CALLOUT_INVENTORY_PATH>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerSupplyFanFault>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerSupplyFanFault;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerSupplyTemperatureFault
+{
+
+struct RAW_STATUS
+{
+    /*
+     * We can't use -fsanitize=undefined if we declare a
+     * 'static constexpr auto str' member, so don't. Instead, open-code the
+     * mako template lookups.
+     */
+    static constexpr auto str_short = "RAW_STATUS";
+    using type = std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>,const char*>;
+    explicit constexpr RAW_STATUS(const char* a) : _entry(entry("RAW_STATUS=%s", a)) {};
+    type _entry;
+};
+
+}  // namespace _PowerSupplyTemperatureFault
+
+struct PowerSupplyTemperatureFault
+{
+    static constexpr auto L = level::ERR;
+    using RAW_STATUS = _PowerSupplyTemperatureFault::RAW_STATUS;
+    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::Inventory::CALLOUT_INVENTORY_PATH;
+    using metadata_types = std::tuple<RAW_STATUS, CALLOUT_INVENTORY_PATH>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerSupplyTemperatureFault>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerSupplyTemperatureFault;
+};
+
+}
 
 namespace org
 {
@@ -1328,22 +3497,20 @@ struct RAW_STATUS
      * mako template lookups.
      */
     static constexpr auto str_short = "RAW_STATUS";
-    using type =
-        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
-    explicit constexpr RAW_STATUS(const char* a) :
-        _entry(entry("RAW_STATUS=%s", a)){};
+    using type = std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>,const char*>;
+    explicit constexpr RAW_STATUS(const char* a) : _entry(entry("RAW_STATUS=%s", a)) {};
     type _entry;
 };
 
-} // namespace _GPUPowerFault
+}  // namespace _GPUPowerFault
 
 struct GPUPowerFault
 {
     static constexpr auto L = level::ERR;
     using RAW_STATUS = _GPUPowerFault::RAW_STATUS;
-    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::
-        Inventory::CALLOUT_INVENTORY_PATH;
+    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::Inventory::CALLOUT_INVENTORY_PATH;
     using metadata_types = std::tuple<RAW_STATUS, CALLOUT_INVENTORY_PATH>;
+
 };
 
 } // namespace Fault
@@ -1351,17 +3518,17 @@ struct GPUPowerFault
 } // namespace open_power
 } // namespace org
 
+
 namespace details
 {
 
 template <>
-struct map_exception_type<
-    sdbusplus::org::open_power::Witherspoon::Fault::Error::GPUPowerFault>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::GPUPowerFault>
 {
     using type = org::open_power::Witherspoon::Fault::GPUPowerFault;
 };
 
-} // namespace details
+}
 
 namespace org
 {
@@ -1382,22 +3549,20 @@ struct RAW_STATUS
      * mako template lookups.
      */
     static constexpr auto str_short = "RAW_STATUS";
-    using type =
-        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
-    explicit constexpr RAW_STATUS(const char* a) :
-        _entry(entry("RAW_STATUS=%s", a)){};
+    using type = std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>,const char*>;
+    explicit constexpr RAW_STATUS(const char* a) : _entry(entry("RAW_STATUS=%s", a)) {};
     type _entry;
 };
 
-} // namespace _GPUOverTemp
+}  // namespace _GPUOverTemp
 
 struct GPUOverTemp
 {
     static constexpr auto L = level::ERR;
     using RAW_STATUS = _GPUOverTemp::RAW_STATUS;
-    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::
-        Inventory::CALLOUT_INVENTORY_PATH;
+    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::Inventory::CALLOUT_INVENTORY_PATH;
     using metadata_types = std::tuple<RAW_STATUS, CALLOUT_INVENTORY_PATH>;
+
 };
 
 } // namespace Fault
@@ -1405,17 +3570,17 @@ struct GPUOverTemp
 } // namespace open_power
 } // namespace org
 
+
 namespace details
 {
 
 template <>
-struct map_exception_type<
-    sdbusplus::org::open_power::Witherspoon::Fault::Error::GPUOverTemp>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::GPUOverTemp>
 {
     using type = org::open_power::Witherspoon::Fault::GPUOverTemp;
 };
 
-} // namespace details
+}
 
 namespace org
 {
@@ -1436,22 +3601,20 @@ struct RAW_STATUS
      * mako template lookups.
      */
     static constexpr auto str_short = "RAW_STATUS";
-    using type =
-        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
-    explicit constexpr RAW_STATUS(const char* a) :
-        _entry(entry("RAW_STATUS=%s", a)){};
+    using type = std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>,const char*>;
+    explicit constexpr RAW_STATUS(const char* a) : _entry(entry("RAW_STATUS=%s", a)) {};
     type _entry;
 };
 
-} // namespace _MemoryPowerFault
+}  // namespace _MemoryPowerFault
 
 struct MemoryPowerFault
 {
     static constexpr auto L = level::ERR;
     using RAW_STATUS = _MemoryPowerFault::RAW_STATUS;
-    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::
-        Inventory::CALLOUT_INVENTORY_PATH;
+    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::Inventory::CALLOUT_INVENTORY_PATH;
     using metadata_types = std::tuple<RAW_STATUS, CALLOUT_INVENTORY_PATH>;
+
 };
 
 } // namespace Fault
@@ -1459,17 +3622,18 @@ struct MemoryPowerFault
 } // namespace open_power
 } // namespace org
 
+
 namespace details
 {
 
 template <>
-struct map_exception_type<
-    sdbusplus::org::open_power::Witherspoon::Fault::Error::MemoryPowerFault>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::MemoryPowerFault>
 {
     using type = org::open_power::Witherspoon::Fault::MemoryPowerFault;
 };
 
-} // namespace details
+}
+
 
 } // namespace logging
 

--- a/org/open_power/Witherspoon/Fault.errors.yaml
+++ b/org/open_power/Witherspoon/Fault.errors.yaml
@@ -24,6 +24,120 @@
 - name: PowerOnFailure
   description: System power failed to turn on
 
+- name: PSUPresentError
+  description: PSU failed to detect
+
+- name: PowerOnErrorCode1
+  description: Power on error reason is PSU1_PGOOD fail
+
+- name: PowerOnErrorCode2
+  description: Power on error reason is PSU0_PGOOD fail
+
+- name: PowerOnErrorCode3
+  description: Power on error reason is 240Va_Fault_A fail
+
+- name: PowerOnErrorCode4
+  description: Power on error reason is 240Va_Fault_B fail
+
+- name: PowerOnErrorCode5
+  description: Power on error reason is 240Va_Fault_C fail
+
+- name: PowerOnErrorCode6
+  description: Power on error reason is 240Va_Fault_D fail
+
+- name: PowerOnErrorCode7
+  description: Power on error reason is 240Va_Fault_E fail
+
+- name: PowerOnErrorCode8
+  description: Power on error reason is 240Va_Fault_F fail
+
+- name: PowerOnErrorCode9
+  description: Power on error reason is 240Va_Fault_G fail
+
+- name: PowerOnErrorCode10
+  description: Power on error reason is 240Va_Fault_H fail
+
+- name: PowerOnErrorCode11
+  description: Power on error reason is 240Va_Fault_J fail
+
+- name: PowerOnErrorCode12
+  description: Power on error reason is 240Va_Fault_K fail
+
+- name: PowerOnErrorCode13
+  description: Power on error reason is 240Va_Fault_L fail
+
+- name: PowerOnErrorCode14
+  description: Power on error reason is P5V_pgood fail
+
+- name: PowerOnErrorCode15
+  description: Power on error reason is P3V3_pgood fail
+
+- name: PowerOnErrorCode16
+  description: Power on error reason is P1V8_pgood fail
+
+- name: PowerOnErrorCode17
+  description: Power on error reason is P1V1_pgood fail
+
+- name: PowerOnErrorCode18
+  description: Power on error reason is P0V9_pgood fail
+
+- name: PowerOnErrorCode19
+  description: Power on error reason is P2V5A_pgood fail
+
+- name: PowerOnErrorCode20
+  description: Power on error reason is P2V5B_pgood fail
+
+- name: PowerOnErrorCode21
+  description: Power on error reason is Vdn0_pgood fail
+
+- name: PowerOnErrorCode22
+  description: Power on error reason is Vdn1_pgood fail
+
+- name: PowerOnErrorCode23
+  description: Power on error reason is P1V5_pgood fail
+
+- name: PowerOnErrorCode24
+  description: Power on error reason is Vio0_pgood fail
+
+- name: PowerOnErrorCode25
+  description: Power on error reason is Vio1_pgood fail
+
+- name: PowerOnErrorCode26
+  description: Power on error reason is Vdd0_pgood fail
+
+- name: PowerOnErrorCode27
+  description: Power on error reason is Vcs0_pgood fail
+
+- name: PowerOnErrorCode28
+  description: Power on error reason is Vdd1_pgood fail
+
+- name: PowerOnErrorCode29
+  description: Power on error reason is Vcs1_pgood fail
+
+- name: PowerOnErrorCode30
+  description: Power on error reason is Vddr0_pgood fail
+
+- name: PowerOnErrorCode31
+  description: Power on error reason is Vtt0_pgood fail
+
+- name: PowerOnErrorCode32
+  description: Power on error reason is Vddr1_pgood fail
+
+- name: PowerOnErrorCode33
+  description: Power on error reason is Vtt1_pgood fail
+
+- name: PowerOnErrorCode34
+  description: Power on error reason is GPU0_pgood fail
+
+- name: PowerOnErrorCode35
+  description: Power on error reason is GPU1_pgood fail
+
+- name: PowerOnErrorCode36
+  description: Power on error reason is PSU0&PSU1_pgood fail
+
+- name: PowerOnErrorCode0
+  description: Read CPLD-register fail
+
 - name: PowerSequencerVoltageFault
   description: The power sequencer chip detected a voltage fault
 

--- a/org/open_power/Witherspoon/Fault.metadata.yaml
+++ b/org/open_power/Witherspoon/Fault.metadata.yaml
@@ -52,6 +52,120 @@
 - name: PowerOnFailure
   level: ERR
 
+- name: PSUPresentError
+  level: ERR
+
+- name: PowerOnErrorCode1
+  level: ERR
+
+- name: PowerOnErrorCode2
+  level: ERR
+
+- name: PowerOnErrorCode3
+  level: ERR
+
+- name: PowerOnErrorCode4
+  level: ERR
+
+- name: PowerOnErrorCode5
+  level: ERR
+
+- name: PowerOnErrorCode6
+  level: ERR
+
+- name: PowerOnErrorCode7
+  level: ERR
+
+- name: PowerOnErrorCode8
+  level: ERR
+
+- name: PowerOnErrorCode9
+  level: ERR
+
+- name: PowerOnErrorCode10
+  level: ERR
+
+- name: PowerOnErrorCode11
+  level: ERR
+
+- name: PowerOnErrorCode12
+  level: ERR
+
+- name: PowerOnErrorCode13
+  level: ERR
+
+- name: PowerOnErrorCode14
+  level: ERR
+
+- name: PowerOnErrorCode15
+  level: ERR
+
+- name: PowerOnErrorCode16
+  level: ERR
+
+- name: PowerOnErrorCode17
+  level: ERR
+
+- name: PowerOnErrorCode18
+  level: ERR
+
+- name: PowerOnErrorCode19
+  level: ERR
+
+- name: PowerOnErrorCode20
+  level: ERR
+
+- name: PowerOnErrorCode21
+  level: ERR
+
+- name: PowerOnErrorCode22
+  level: ERR
+
+- name: PowerOnErrorCode23
+  level: ERR
+
+- name: PowerOnErrorCode24
+  level: ERR
+
+- name: PowerOnErrorCode25
+  level: ERR
+
+- name: PowerOnErrorCode26
+  level: ERR
+
+- name: PowerOnErrorCode27
+  level: ERR
+
+- name: PowerOnErrorCode28
+  level: ERR
+
+- name: PowerOnErrorCode29
+  level: ERR
+
+- name: PowerOnErrorCode30
+  level: ERR
+
+- name: PowerOnErrorCode31
+  level: ERR
+
+- name: PowerOnErrorCode32
+  level: ERR
+
+- name: PowerOnErrorCode33
+  level: ERR
+
+- name: PowerOnErrorCode34
+  level: ERR
+
+- name: PowerOnErrorCode35
+  level: ERR
+
+- name: PowerOnErrorCode36
+  level: ERR
+
+- name: PowerOnErrorCode0
+  level: ERR
+
 - name: PowerSequencerVoltageFault
   level: ERR
   meta:

--- a/power-sequencer/Makefile.am
+++ b/power-sequencer/Makefile.am
@@ -9,12 +9,14 @@ pseq_monitor_SOURCES = \
 	main.cpp \
 	pgood_monitor.cpp \
 	runtime_monitor.cpp \
-	ucd90160.cpp
+	ucd90160.cpp \
+	mihawk-cpld.cpp
 
 nodist_pseq_monitor_SOURCES = \
 	ucd90160_defs.cpp
 
 pseq_monitor_LDADD = \
+	-li2c \
 	$(top_builddir)/libpower.la \
 	$(PHOSPHOR_LOGGING_LIBS) \
 	${PHOSPHOR_DBUS_INTERFACES_LIBS} \

--- a/power-sequencer/mihawk-cpld.cpp
+++ b/power-sequencer/mihawk-cpld.cpp
@@ -1,0 +1,375 @@
+#include "config.h"
+
+#include "mihawk-cpld.hpp"
+
+#include "utility.hpp"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <elog-errors.hpp>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <org/open_power/Witherspoon/Fault/error.hpp>
+#include <phosphor-logging/elog.hpp>
+#include <phosphor-logging/log.hpp>
+#include <string>
+#include <xyz/openbmc_project/Common/Device/error.hpp>
+
+extern "C" {
+#include <i2c/smbus.h>
+#include <linux/i2c-dev.h>
+#include <linux/i2c.h>
+}
+
+// i2c bus & i2c slave address of Mihawk's CPLD
+#define busId 11
+#define slaveAddr 0x40
+
+// SMLink Status Register(Interrupt-control-bit Register)
+const static constexpr size_t StatusReg_1 = 0x20;
+
+// SMLink Status Register(Power-on error code Register)
+const static constexpr size_t StatusReg_2 = 0x21;
+
+using namespace std;
+namespace witherspoon
+{
+namespace power
+{
+const auto DEVICE_NAME = "MihawkCPLD"s;
+
+namespace fs = std::filesystem;
+using namespace phosphor::logging;
+
+using namespace sdbusplus::org::open_power::Witherspoon::Fault::Error;
+
+namespace device_error = sdbusplus::xyz::openbmc_project::Common::Device::Error;
+
+MihawkCPLD::MihawkCPLD(size_t instance, sdbusplus::bus::bus& bus) :
+    Device(DEVICE_NAME, instance), bus(bus)
+{
+}
+
+void MihawkCPLD::onFailure()
+{
+    bool poweronError = checkPoweronFault();
+    // If the interrupt of power_on_error is switch on,
+    // read CPLD_register error code to analyze and report the error event.
+    if (poweronError)
+    {
+        std::cerr << "CPLD : Power_ON error! \n";
+        int errorcode;
+        errorcode = readFromCPLDPSUErrorCode(busId, slaveAddr);
+        if (errorcode == powerOnErrorCode_0)
+        {
+            report<PowerOnErrorCode0>();
+        }
+        else if (errorcode == powerOnErrorCode_1)
+        {
+            report<PowerOnErrorCode1>();
+        }
+        else if (errorcode == powerOnErrorCode_2)
+        {
+            report<PowerOnErrorCode2>();
+        }
+        else if (errorcode == powerOnErrorCode_3)
+        {
+            report<PowerOnErrorCode3>();
+        }
+        else if (errorcode == powerOnErrorCode_4)
+        {
+            report<PowerOnErrorCode4>();
+        }
+        else if (errorcode == powerOnErrorCode_5)
+        {
+            report<PowerOnErrorCode5>();
+        }
+        else if (errorcode == powerOnErrorCode_6)
+        {
+            report<PowerOnErrorCode6>();
+        }
+        else if (errorcode == powerOnErrorCode_7)
+        {
+            report<PowerOnErrorCode7>();
+        }
+        else if (errorcode == powerOnErrorCode_8)
+        {
+            report<PowerOnErrorCode8>();
+        }
+        else if (errorcode == powerOnErrorCode_9)
+        {
+            report<PowerOnErrorCode9>();
+        }
+        else if (errorcode == powerOnErrorCode_10)
+        {
+            report<PowerOnErrorCode10>();
+        }
+        else if (errorcode == powerOnErrorCode_11)
+        {
+            report<PowerOnErrorCode11>();
+        }
+        else if (errorcode == powerOnErrorCode_12)
+        {
+            report<PowerOnErrorCode12>();
+        }
+        else if (errorcode == powerOnErrorCode_13)
+        {
+            report<PowerOnErrorCode13>();
+        }
+        else if (errorcode == powerOnErrorCode_14)
+        {
+            report<PowerOnErrorCode14>();
+        }
+        else if (errorcode == powerOnErrorCode_15)
+        {
+            report<PowerOnErrorCode15>();
+        }
+        else if (errorcode == powerOnErrorCode_16)
+        {
+            report<PowerOnErrorCode16>();
+        }
+        else if (errorcode == powerOnErrorCode_17)
+        {
+            report<PowerOnErrorCode17>();
+        }
+        else if (errorcode == powerOnErrorCode_18)
+        {
+            report<PowerOnErrorCode18>();
+        }
+        else if (errorcode == powerOnErrorCode_19)
+        {
+            report<PowerOnErrorCode19>();
+        }
+        else if (errorcode == powerOnErrorCode_20)
+        {
+            report<PowerOnErrorCode20>();
+        }
+        else if (errorcode == powerOnErrorCode_21)
+        {
+            report<PowerOnErrorCode21>();
+        }
+        else if (errorcode == powerOnErrorCode_22)
+        {
+            report<PowerOnErrorCode22>();
+        }
+        else if (errorcode == powerOnErrorCode_23)
+        {
+            report<PowerOnErrorCode23>();
+        }
+        else if (errorcode == powerOnErrorCode_24)
+        {
+            report<PowerOnErrorCode24>();
+        }
+        else if (errorcode == powerOnErrorCode_25)
+        {
+            report<PowerOnErrorCode25>();
+        }
+        else if (errorcode == powerOnErrorCode_26)
+        {
+            report<PowerOnErrorCode26>();
+        }
+        else if (errorcode == powerOnErrorCode_27)
+        {
+            report<PowerOnErrorCode27>();
+        }
+        else if (errorcode == powerOnErrorCode_28)
+        {
+            report<PowerOnErrorCode28>();
+        }
+        else if (errorcode == powerOnErrorCode_29)
+        {
+            report<PowerOnErrorCode29>();
+        }
+        else if (errorcode == powerOnErrorCode_30)
+        {
+            report<PowerOnErrorCode30>();
+        }
+        else if (errorcode == powerOnErrorCode_31)
+        {
+            report<PowerOnErrorCode31>();
+        }
+        else if (errorcode == powerOnErrorCode_32)
+        {
+            report<PowerOnErrorCode32>();
+        }
+        else if (errorcode == powerOnErrorCode_33)
+        {
+            report<PowerOnErrorCode33>();
+        }
+        else if (errorcode == powerOnErrorCode_34)
+        {
+            report<PowerOnErrorCode34>();
+        }
+        else if (errorcode == powerOnErrorCode_35)
+        {
+            report<PowerOnErrorCode35>();
+        }
+        else if (errorcode == powerOnErrorCode_36)
+        {
+            report<PowerOnErrorCode36>();
+        }
+        clearCPLDregister();
+    }
+}
+
+void MihawkCPLD::analyze()
+{
+}
+
+// Read CPLD_register error code and return the result to analyze.
+int MihawkCPLD::readFromCPLDPSUErrorCode(int bus, int Addr)
+{
+    std::string i2cBus = "/dev/i2c-" + std::to_string(bus);
+
+    // open i2c device(CPLD-PSU-register table)
+    int fd = open(i2cBus.c_str(), O_RDWR | O_CLOEXEC);
+    if (fd < 0)
+    {
+        std::cerr << "Unable to open i2c device(CPLD_register) \n";
+    }
+
+    // set i2c slave address
+    if (ioctl(fd, I2C_SLAVE_FORCE, Addr) < 0)
+    {
+        std::cerr << "Unable to set device address \n";
+        close(fd);
+    }
+
+    // check whether support i2c function
+    unsigned long funcs = 0;
+    if (ioctl(fd, I2C_FUNCS, &funcs) < 0)
+    {
+        std::cerr << "Not support I2C_FUNCS \n";
+        close(fd);
+    }
+
+    // check whether support i2c-read function
+    if (!(funcs & I2C_FUNC_SMBUS_READ_BYTE_DATA))
+    {
+        std::cerr << "Not support I2C_FUNC_SMBUS_READ_BYTE_DATA \n";
+        close(fd);
+    }
+
+    int statusValue;
+
+    statusValue = i2c_smbus_read_byte_data(fd, StatusReg_2);
+    close(fd);
+
+    if (statusValue < 0)
+    {
+        statusValue = 0;
+    }
+
+    // return the i2c-read data
+    return statusValue;
+}
+
+// Check for PoweronFault
+bool MihawkCPLD::checkPoweronFault()
+{
+    bool result = 0;
+    std::string i2cBus = "/dev/i2c-" + std::to_string(busId);
+
+    // open i2c device(CPLD-PSU-register table)
+    int fd = open(i2cBus.c_str(), O_RDWR | O_CLOEXEC);
+    if (fd < 0)
+    {
+        std::cerr << "Unable to open i2c device \n";
+    }
+
+    // set i2c slave address
+    if (ioctl(fd, I2C_SLAVE_FORCE, slaveAddr) < 0)
+    {
+        std::cerr << "Unable to set device address \n";
+        close(fd);
+    }
+
+    // check whether support i2c function
+    unsigned long funcs = 0;
+    if (ioctl(fd, I2C_FUNCS, &funcs) < 0)
+    {
+        std::cerr << "Not support I2C_FUNCS \n";
+        close(fd);
+    }
+
+    // check whether support i2c-read function
+    if (!(funcs & I2C_FUNC_SMBUS_READ_BYTE_DATA))
+    {
+        std::cerr << "Not support I2C_FUNC_SMBUS_READ_BYTE_DATA \n";
+        close(fd);
+    }
+
+    int statusValue_1;
+
+    statusValue_1 = i2c_smbus_read_byte_data(fd, StatusReg_1);
+    close(fd);
+
+    if (statusValue_1 < 0)
+    {
+        std::cerr << "i2c_smbus_read_byte_data failed \n";
+        result = 0;
+    }
+
+    if((statusValue_1 >> 5) & 1)
+    {
+        // If power_on-interrupt-bit is read as 1,
+        // switch on the flag.
+        result = 1;
+        std::cerr << "result_1= " << result << "\n"; 
+    }
+    else
+    {
+        result = 0;
+    }
+
+    return result;
+}
+
+// Clear CPLD_register after reading.
+void MihawkCPLD::clearCPLDregister()
+{
+    std::string i2cBus = "/dev/i2c-" + std::to_string(busId);
+
+    // open i2c device(CPLD-PSU-register table)
+    int fd = open(i2cBus.c_str(), O_RDWR | O_CLOEXEC);
+    if (fd < 0)
+    {
+        std::cerr << "Unable to open i2c device \n";
+    }
+
+    // set i2c slave address
+    if (ioctl(fd, I2C_SLAVE_FORCE, slaveAddr) < 0)
+    {
+        std::cerr << "Unable to set device address \n";
+        close(fd);
+    }
+
+    // check whether support i2c function
+    unsigned long funcs = 0;
+    if (ioctl(fd, I2C_FUNCS, &funcs) < 0)
+    {
+        std::cerr << "Not support I2C_FUNCS \n";
+        close(fd);
+    }
+
+    // check whether support i2c-read function
+    if (!(funcs & I2C_FUNC_SMBUS_READ_BYTE_DATA))
+    {
+        std::cerr << "Not support I2C_FUNC_SMBUS_READ_BYTE_DATA \n";
+        close(fd);
+    }
+
+    if ((i2c_smbus_write_byte_data(fd, StatusReg_1, 0x01)) < 0)
+    {
+        std::cerr << "i2c_smbus_write_byte_data failed \n";
+    }
+    close(fd);
+}
+
+} // namespace power
+} // namespace witherspoon

--- a/power-sequencer/mihawk-cpld.hpp
+++ b/power-sequencer/mihawk-cpld.hpp
@@ -1,0 +1,322 @@
+#pragma once
+
+#include "device.hpp"
+#include "pmbus.hpp"
+
+#include <algorithm>
+#include <filesystem>
+#include <sdbusplus/bus.hpp>
+
+namespace witherspoon
+{
+namespace power
+{
+
+/**
+ * @class MihawkCPLD
+ *
+ * This class implements fault analysis for Mihawk's CPLD
+ * power sequencer device.
+ *
+ */
+class MihawkCPLD : public Device
+{
+  public:
+    MihawkCPLD() = delete;
+    ~MihawkCPLD() = default;
+    MihawkCPLD(const MihawkCPLD&) = delete;
+    MihawkCPLD& operator=(const MihawkCPLD&) = delete;
+    MihawkCPLD(MihawkCPLD&&) = default;
+    MihawkCPLD& operator=(MihawkCPLD&&) = default;
+
+    /**
+     * Constructor
+     *
+     * @param[in] instance - the device instance number
+     * @param[in] bus - D-Bus bus object
+     */
+    MihawkCPLD(size_t instance, sdbusplus::bus::bus& bus);
+
+    /**
+     * Analyzes the device for errors when the device is
+     * known to be in an error state.  A log will be created.
+     */
+    void onFailure() override;
+
+    /**
+     * Checks the device for errors and only creates a log
+     * if one is found.
+     */
+    void analyze() override;
+
+    /**
+     * Clears faults in the device
+     */
+    void clearFaults() override
+    {
+    }
+
+  private:
+    /**
+     * If checkPoweronFault() returns "true",
+     * use ReadFromCPLDPSUErrorCode() to read CPLD-error-code-register
+     * to analyze the fail reason.
+     *
+     * @param[in] bus - I2C's bus, ex.i2c-11.
+     * Mihawk's CPLD-register is on i2c-11.
+     *
+     * @param[in] Addr - the i2c-11 address of Mihawk's CPLD-register.
+     *
+     * @return int - the error-code value which is read on
+     * CPLD-error-code-register.
+     */
+    int readFromCPLDPSUErrorCode(int bus, int Addr);
+
+    /**
+     * Checks for PoweronFault on Mihawk's
+     * CPLD-power_on-error-interrupt-bit-register
+     * whether is transfered to "1".
+     *
+     * @return bool - true if power_on fail.
+     */
+    bool checkPoweronFault();
+
+    /**
+     * The D-Bus bus object
+     */
+    sdbusplus::bus::bus& bus;
+
+    /**
+     * Clear CPLD intrupt record after reading CPLD_register.
+     */
+    void clearCPLDregister();
+
+    /**
+     * All of powerOnErrorcode are the definition of error-code
+     * which are read on CPLD-error-code-register. 
+     */
+    /**
+     * The definition of error-code:
+     *  
+     */
+    int powerOnErrorCode_0 = 0;
+
+    /**
+     * The definition of error-code:
+     * PSU1_PGOOD fail.
+     */
+    int powerOnErrorCode_1 = 1;
+
+    /**
+     * The definition of error-code:
+     * PSU0_PGOOD fail.
+     */
+    int powerOnErrorCode_2 = 2;
+
+    /**
+     * The definition of error-code:
+     * 240Va_Fault_A fail.
+     */
+    int powerOnErrorCode_3 = 3;
+
+    /**
+     * The definition of error-code:
+     * 240Va_Fault_B fail.
+     */
+    int powerOnErrorCode_4 = 4;
+
+    /**
+     * The definition of error-code:
+     * 240Va_Fault_C fail.
+     */
+    int powerOnErrorCode_5 = 5;
+
+    /**
+     * The definition of error-code:
+     * 240Va_Fault_D fail.
+     */
+    int powerOnErrorCode_6 = 6;
+
+    /**
+     * The definition of error-code:
+     * 240Va_Fault_E fail.
+     */
+    int powerOnErrorCode_7 = 7;
+
+    /**
+     * The definition of error-code:
+     * 240Va_Fault_F fail.
+     */
+    int powerOnErrorCode_8 = 8;
+
+    /**
+     * The definition of error-code:
+     * 240Va_Fault_G fail.
+     */
+    int powerOnErrorCode_9 = 9;
+
+    /**
+     * The definition of error-code:
+     * 240Va_Fault_H fail.
+     */
+    int powerOnErrorCode_10 = 10;
+
+    /**
+     * The definition of error-code:
+     * 240Va_Fault_J fail.
+     */
+    int powerOnErrorCode_11 = 11;
+
+    /**
+     * The definition of error-code:
+     * 240Va_Fault_K fail.
+     */
+    int powerOnErrorCode_12 = 12;
+
+    /**
+     * The definition of error-code:
+     * 240Va_Fault_L fail.
+     */
+    int powerOnErrorCode_13 = 13;
+
+    /**
+     * The definition of error-code:
+     * P5V_PGOOD fail.
+     */
+    int powerOnErrorCode_14 = 14;
+
+    /**
+     * The definition of error-code:
+     * P3V3_PGOOD fail.
+     */
+    int powerOnErrorCode_15 = 15;
+
+    /**
+     * The definition of error-code:
+     * P1V8_PGOOD fail.
+     */
+    int powerOnErrorCode_16 = 16;
+
+    /**
+     * The definition of error-code:
+     * P1V1_PGOOD fail.
+     */
+    int powerOnErrorCode_17 = 17;
+
+    /**
+     * The definition of error-code:
+     * P0V9_PGOOD fail.
+     */
+    int powerOnErrorCode_18 = 18;
+
+    /**
+     * The definition of error-code:
+     * P2V5A_PGOOD fail.
+     */
+    int powerOnErrorCode_19 = 19;
+
+    /**
+     * The definition of error-code:
+     * P2V5B_PGOOD fail.
+     */
+    int powerOnErrorCode_20 = 20;
+
+    /**
+     * The definition of error-code:
+     * Vdn0_PGOOD fail.
+     */
+    int powerOnErrorCode_21 = 21;
+
+    /**
+     * The definition of error-code:
+     * Vdn1_PGOOD fail.
+     */
+    int powerOnErrorCode_22 = 22;
+
+    /**
+     * The definition of error-code:
+     * P1V5_PGOOD fail.
+     */
+    int powerOnErrorCode_23 = 23;
+
+    /**
+     * The definition of error-code:
+     * Vio0_PGOOD fail.
+     */
+    int powerOnErrorCode_24 = 24;
+
+    /**
+     * The definition of error-code:
+     * Vio1_PGOOD fail.
+     */
+    int powerOnErrorCode_25 = 25;
+
+    /**
+     * The definition of error-code:
+     * Vdd0_PGOOD fail.
+     */
+    int powerOnErrorCode_26 = 26;
+
+    /**
+     * The definition of error-code:
+     * Vcs0_PGOOD fail.
+     */
+    int powerOnErrorCode_27 = 27;
+
+    /**
+     * The definition of error-code:
+     * Vdd1_PGOOD fail.
+     */
+    int powerOnErrorCode_28 = 28;
+
+    /**
+     * The definition of error-code:
+     * Vcs1_PGOOD fail.
+     */
+    int powerOnErrorCode_29 = 29;
+
+    /**
+     * The definition of error-code:
+     * Vddr0_PGOOD fail.
+     */
+    int powerOnErrorCode_30 = 30;
+
+    /**
+     * The definition of error-code:
+     * Vtt0_PGOOD fail.
+     */
+    int powerOnErrorCode_31 = 31;
+
+    /**
+     * The definition of error-code:
+     * Vddr1_PGOOD fail.
+     */
+    int powerOnErrorCode_32 = 32;
+
+    /**
+     * The definition of error-code:
+     * Vtt1_PGOOD fail.
+     */
+    int powerOnErrorCode_33 = 33;
+
+    /**
+     * The definition of error-code:
+     * GPU0_PGOOD fail.
+     */
+    int powerOnErrorCode_34 = 34;
+
+    /**
+     * The definition of error-code:
+     * GPU1_PGOOD fail.
+     */
+    int powerOnErrorCode_35 = 35;
+
+    /**
+     * The definition of error-code:
+     * PSU0PSU1_PGOOD fail.
+     */
+    int powerOnErrorCode_36 = 170;
+};
+
+} // namespace power
+} // namespace witherspoon


### PR DESCRIPTION
Add CPLD class for Mihawk platform(2019-10-18)

**This revision is based on the last commit suggestion.** 

If PGOOD signal is abnormal when chassis poweron, read
Mihawk's CPLD-register via I2C to confirm the error.

First confirm whether the PSU is present, then confirm
whether the power_on_error signal is 1 (1 means abnormal).
If the signal is 1, read the error-code-register to
analysis reason.

Tested:
Use command "obmcutil chassiskill" to trigger PGOOD error
action analysis during chassis power on.

