### PR TITLE
Add runtime-action of power-sequencer & add the role of #ifndef on psu-monitor for mihawk platform

### DIFF
--- a/elog-errors.hpp
+++ b/elog-errors.hpp
@@ -71,22 +71,22 @@ namespace Error
 
 namespace sdbusplus
 {
-namespace xyz
+namespace org
 {
-namespace openbmc_project
+namespace open_power
 {
-namespace Common
+namespace Witherspoon
 {
-namespace Callout
+namespace Fault
 {
 namespace Error
 {
-    struct GPIO;
+    struct PsuErrorCode1;
 } // namespace Error
-} // namespace Callout
-} // namespace Common
-} // namespace openbmc_project
-} // namespace xyz
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
 } // namespace sdbusplus
 
 namespace sdbusplus
@@ -481,6 +481,26 @@ namespace Fault
 {
 namespace Error
 {
+    struct PsuErrorCode0;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
     struct PowerOnErrorCode30;
 } // namespace Error
 } // namespace Fault
@@ -567,6 +587,26 @@ namespace Error
 } // namespace Witherspoon
 } // namespace open_power
 } // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace xyz
+{
+namespace openbmc_project
+{
+namespace Common
+{
+namespace Callout
+{
+namespace Error
+{
+    struct GPIO;
+} // namespace Error
+} // namespace Callout
+} // namespace Common
+} // namespace openbmc_project
+} // namespace xyz
 } // namespace sdbusplus
 
 namespace sdbusplus
@@ -1208,6 +1248,44 @@ template <>
 struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnFailure>
 {
     using type = org::open_power::Witherspoon::Fault::PowerOnFailure;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode0
+{
+
+
+}  // namespace _PowerOnErrorCode0
+
+struct PowerOnErrorCode0
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode0>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode0;
 };
 
 }
@@ -2588,13 +2666,13 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode0
+namespace _PsuErrorCode0
 {
 
 
-}  // namespace _PowerOnErrorCode0
+}  // namespace _PsuErrorCode0
 
-struct PowerOnErrorCode0
+struct PsuErrorCode0
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
@@ -2611,9 +2689,47 @@ namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode0>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PsuErrorCode0>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode0;
+    using type = org::open_power::Witherspoon::Fault::PsuErrorCode0;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PsuErrorCode1
+{
+
+
+}  // namespace _PsuErrorCode1
+
+struct PsuErrorCode1
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PsuErrorCode1>
+{
+    using type = org::open_power::Witherspoon::Fault::PsuErrorCode1;
 };
 
 }

--- a/org/open_power/Witherspoon/Fault.errors.yaml
+++ b/org/open_power/Witherspoon/Fault.errors.yaml
@@ -24,6 +24,9 @@
 - name: PowerOnFailure
   description: System power failed to turn on
 
+- name: PowerOnErrorCode0
+  description: Read CPLD-register fail
+  
 - name: PowerOnErrorCode1
   description: Power on error reason is PSU1_PGOOD fail
 
@@ -132,8 +135,11 @@
 - name: PowerOnErrorCode36
   description: Power on error reason is PSU0&PSU1_pgood fail
 
-- name: PowerOnErrorCode0
-  description: Read CPLD-register fail
+- name: PsuErrorCode0
+  description: PSU1 power fail
+
+- name: PsuErrorCode1
+  description: PSU0 power fail
 
 - name: PowerSequencerVoltageFault
   description: The power sequencer chip detected a voltage fault

--- a/org/open_power/Witherspoon/Fault.metadata.yaml
+++ b/org/open_power/Witherspoon/Fault.metadata.yaml
@@ -163,6 +163,12 @@
 - name: PowerOnErrorCode0
   level: ERR
 
+- name: PsuErrorCode0
+  level: ERR
+
+- name: PsuErrorCode1
+  level: ERR
+
 - name: PowerSequencerVoltageFault
   level: ERR
   meta:

--- a/power-sequencer/main.cpp
+++ b/power-sequencer/main.cpp
@@ -32,9 +32,7 @@ int main(int argc, char** argv)
     ArgumentParser args{argc, argv};
     auto action = args["action"];
 
-    if ((action != "pgood-monitor") &&
-        (action != "mihawk-cpld-pgood-monitor") &&
-        (action != "runtime-monitor"))
+    if ((action != "pgood-monitor") && (action != "runtime-monitor"))
     {
         std::cerr << "Invalid action\n";
         args.usage(argv);
@@ -54,22 +52,18 @@ int main(int argc, char** argv)
     auto bus = sdbusplus::bus::new_default();
     bus.attach_event(event.get(), SD_EVENT_PRIORITY_NORMAL);
 
+#ifdef UCD90160_DEVICE_ACCESS
+    auto device = std::make_unique<UCD90160>(0, bus);
+#else
+    auto device = std::make_unique<MIHAWKCPLD>(0, bus);
+#endif
+
     std::unique_ptr<DeviceMonitor> monitor;
 
     if (action == "pgood-monitor")
     {
         // If PGOOD doesn't turn on within a certain
         // time, analyze the device for errors
-        auto device = std::make_unique<UCD90160>(0, bus);
-        monitor = std::make_unique<PGOODMonitor>(std::move(device), bus, event,
-                                                 interval);
-    }
-    else if (action == "mihawk-cpld-pgood-monitor")
-    {
-        // Add new action for Mihawk:
-        // If PGOOD doesn't turn on within a certain
-        // time, analyze CPLD for errors
-        auto device = std::make_unique<MIHAWKCPLD>(0, bus);
         monitor = std::make_unique<PGOODMonitor>(std::move(device), bus, event,
                                                  interval);
     }
@@ -77,7 +71,6 @@ int main(int argc, char** argv)
     {
         // Continuously monitor this device both by polling
         // and on 'power lost' signals.
-        auto device = std::make_unique<UCD90160>(0, bus);
         monitor = std::make_unique<RuntimeMonitor>(std::move(device), bus,
                                                    event, interval);
     }

--- a/power-sequencer/mihawk-cpld.cpp
+++ b/power-sequencer/mihawk-cpld.cpp
@@ -36,6 +36,9 @@ const static constexpr size_t StatusReg_1 = 0x20;
 // SMLink Status Register(Power-on error code Register)
 const static constexpr size_t StatusReg_2 = 0x21;
 
+// SMLink Status Register(PSU register code Register)
+const static constexpr size_t StatusReg_3 = 0x05;
+
 using namespace std;
 namespace witherspoon
 {
@@ -56,6 +59,7 @@ MIHAWKCPLD::MIHAWKCPLD(size_t instance, sdbusplus::bus::bus& bus) :
 void MIHAWKCPLD::onFailure()
 {
     bool poweronError = checkPoweronFault();
+
     // If the interrupt of power_on_error is switch on,
     // read CPLD_register error code to analyze and report the error event.
     if (poweronError)
@@ -217,54 +221,21 @@ void MIHAWKCPLD::onFailure()
 
 void MIHAWKCPLD::analyze()
 {
-}
-
-// Read CPLD_register error code and return the result to analyze.
-int MIHAWKCPLD::readFromCPLDPSUErrorCode(int bus, int Addr)
-{
-    std::string i2cBus = "/dev/i2c-" + std::to_string(bus);
-
-    // open i2c device(CPLD-PSU-register table)
-    int fd = open(i2cBus.c_str(), O_RDWR | O_CLOEXEC);
-    if (fd < 0)
+    //analyze psu status when power_on fault.
+    auto poweronError = checkPoweronFault();
+    if(poweronError)
     {
-        std::cerr << "Unable to open i2c device(CPLD_register) \n";
+        int errorcode;
+        errorcode = checkPSUDCpgood(true);
+        if (!((errorcode >> 1) & 0) && !((errorcode >> 3) & 0) )
+        {
+            report<PsuErrorCode0>();
+        }
+        else if (!((errorcode >> 2) & 0) && !((errorcode >> 4) & 0))
+        {
+            report<PsuErrorCode1>();
+        }
     }
-
-    // set i2c slave address
-    if (ioctl(fd, I2C_SLAVE_FORCE, Addr) < 0)
-    {
-        std::cerr << "Unable to set device address \n";
-        close(fd);
-    }
-
-    // check whether support i2c function
-    unsigned long funcs = 0;
-    if (ioctl(fd, I2C_FUNCS, &funcs) < 0)
-    {
-        std::cerr << "Not support I2C_FUNCS \n";
-        close(fd);
-    }
-
-    // check whether support i2c-read function
-    if (!(funcs & I2C_FUNC_SMBUS_READ_BYTE_DATA))
-    {
-        std::cerr << "Not support I2C_FUNC_SMBUS_READ_BYTE_DATA \n";
-        close(fd);
-    }
-
-    int statusValue;
-
-    statusValue = i2c_smbus_read_byte_data(fd, StatusReg_2);
-    close(fd);
-
-    if (statusValue < 0)
-    {
-        statusValue = 0;
-    }
-
-    // return the i2c-read data
-    return statusValue;
 }
 
 // Check for PoweronFault
@@ -303,7 +274,7 @@ bool MIHAWKCPLD::checkPoweronFault()
     }
 
     int statusValue_1;
-
+    
     statusValue_1 = i2c_smbus_read_byte_data(fd, StatusReg_1);
     close(fd);
 
@@ -313,7 +284,7 @@ bool MIHAWKCPLD::checkPoweronFault()
         result = 0;
     }
 
-    if((statusValue_1 >> 5) & 1)
+    if ((statusValue_1 >> 5) & 1)
     {
         // If power_on-interrupt-bit is read as 1,
         // switch on the flag.
@@ -325,6 +296,95 @@ bool MIHAWKCPLD::checkPoweronFault()
     }
 
     return result;
+}
+
+// Read CPLD_register error code and return the result to analyze.
+int MIHAWKCPLD::readFromCPLDPSUErrorCode(int bus, int Addr)
+{
+    std::string i2cBus = "/dev/i2c-" + std::to_string(bus);
+
+    // open i2c device(CPLD-PSU-register table)
+    int fd = open(i2cBus.c_str(), O_RDWR | O_CLOEXEC);
+    if (fd < 0)
+    {
+        std::cerr << "Unable to open i2c device(CPLD_register) \n";
+    }
+
+    // set i2c slave address
+    if (ioctl(fd, I2C_SLAVE_FORCE, Addr) < 0)
+    {
+        std::cerr << "Unable to set device address \n";
+        close(fd);
+    }
+
+    // check whether support i2c function
+    unsigned long funcs = 0;
+    if (ioctl(fd, I2C_FUNCS, &funcs) < 0)
+    {
+        std::cerr << "Not support I2C_FUNCS \n";
+        close(fd);
+    }
+
+    // check whether support i2c-read function
+    if (!(funcs & I2C_FUNC_SMBUS_READ_BYTE_DATA))
+    {
+        std::cerr << "Not support I2C_FUNC_SMBUS_READ_BYTE_DATA \n";
+        close(fd);
+    }
+
+    int statusValue_2;
+    statusValue_2 = i2c_smbus_read_byte_data(fd, StatusReg_2);
+    close(fd);
+
+    if (statusValue_2 < 0)
+    {
+        statusValue_2 = 0;
+    }
+
+    // return the i2c-read data
+    return statusValue_2;
+}
+
+// Check PSU_DC_PGOOD state form PSU register via CPLD
+bool MIHAWKCPLD::checkPSUDCpgood(bool polling)
+{
+    std::string i2cBus = "/dev/i2c-" + std::to_string(busId);
+
+    // open i2c device(CPLD-PSU-register table)
+    int fd = open(i2cBus.c_str(), O_RDWR | O_CLOEXEC);
+    if (fd < 0)
+    {
+        std::cerr << "Unable to open i2c device \n";
+    }
+
+    // set i2c slave address
+    if (ioctl(fd, I2C_SLAVE_FORCE, slaveAddr) < 0)
+    {
+        std::cerr << "Unable to set device address \n";
+        close(fd);
+    }
+
+    // check whether support i2c function
+    unsigned long funcs = 0;
+    if (ioctl(fd, I2C_FUNCS, &funcs) < 0)
+    {
+        std::cerr << "Not support I2C_FUNCS \n";
+        close(fd);
+    }
+
+    // check whether support i2c-read function
+    if (!(funcs & I2C_FUNC_SMBUS_READ_BYTE_DATA))
+    {
+        std::cerr << "Not support I2C_FUNC_SMBUS_READ_BYTE_DATA \n";
+        close(fd);
+    }
+
+    int statusValue_3;
+    statusValue_3 = i2c_smbus_read_byte_data(fd, StatusReg_3);
+    close(fd);
+
+    // return the i2c-read data
+    return statusValue_3;
 }
 
 // Clear CPLD_register after reading.

--- a/power-sequencer/mihawk-cpld.hpp
+++ b/power-sequencer/mihawk-cpld.hpp
@@ -82,14 +82,19 @@ class MIHAWKCPLD : public Device
     bool checkPoweronFault();
 
     /**
-     * The D-Bus bus object
-     */
-    sdbusplus::bus::bus& bus;
-
-    /**
      * Clear CPLD intrupt record after reading CPLD_register.
      */
     void clearCPLDregister();
+
+    /**
+     * Check PSU power status via runtime-monitor after power_on_fault.
+     */
+    bool checkPSUDCpgood(bool polling);
+
+    /**
+     * The D-Bus bus object
+     */
+    sdbusplus::bus::bus& bus;
 
     /**
      * All of powerOnErrorcode are the definition of error-code

--- a/power-sequencer/runtime_monitor.cpp
+++ b/power-sequencer/runtime_monitor.cpp
@@ -33,7 +33,7 @@ using namespace sdbusplus::org::open_power::Witherspoon::Fault::Error;
 
 int RuntimeMonitor::run()
 {
-#ifdef UCD90160_DEVICE_ACCESS
+#if defined UCD90160_DEVICE_ACCESS || defined MIHAWKCPLD_DEVICE_ACCESS
     return DeviceMonitor::run();
 #else
     return EXIT_SUCCESS;
@@ -48,7 +48,7 @@ void RuntimeMonitor::onPowerLost(sdbusplus::message::message& msg)
     {
         timer.setEnabled(false);
 
-#ifdef UCD90160_DEVICE_ACCESS
+#if defined UCD90160_DEVICE_ACCESS || defined MIHAWKCPLD_DEVICE_ACCESS
         device->onFailure();
 #endif
         // Note: This application only runs when the system has


### PR DESCRIPTION
Add runtime-action of power-sequencer for mihawk.
Check psu power status via runtime-monitor after 
power_on_fault.

Fix mihawk's psu-monitor errors.
Because mihawk's psu doesn't have input_history 
function, add the condition in power-supply.cpp to 
resolve the error of reporting INPUT fail. 

***
This version is modified for OP940.
Due to different architectures for master, so this version 
has not been pushed to upstream.

Tested:
Use command "obmcutil chassiskill" to trigger PGOOD error
action analysis during chassis power on.

Signed-off-by: Andy YF Wang <Andy_YF_Wang@wistron.com>