### PR TITLE
Add runtime-monitor and add conditionto power_supply.cpp for mihawk

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -118,6 +118,12 @@ AC_DEFINE_UNQUOTED([INPUT_HISTORY_SENSOR_ROOT],
                    ["$INPUT_HISTORY_SENSOR_ROOT"],
                    [The D-Bus power sensors namespace root])
 
+AC_ARG_VAR(MIHAWK_PSU_NOT_ACCESS, [Turn on MIHAWK_PSU_NOT_ACCESS])
+AS_IF([test "x$INPUT_HISTORY_BUSNAME_ROOT" == "x"],
+      [MIHAWK_PSU_NOT_ACCESS = "yes"]
+      AC_DEFINE_UNQUOTED([MIHAWK_PSU_NOT_ACCESS], ["$MIHAWK_PSU_NOT_ACCESS"], [Turn on MIHAWK_PSU_NOT_ACCESS])
+)
+
 # Create configured output
 AC_CONFIG_FILES([Makefile power-sequencer/Makefile power-supply/Makefile test/Makefile power-supply/test/Makefile])
 AC_OUTPUT

--- a/elog-errors.hpp
+++ b/elog-errors.hpp
@@ -71,22 +71,22 @@ namespace Error
 
 namespace sdbusplus
 {
-namespace xyz
+namespace org
 {
-namespace openbmc_project
+namespace open_power
 {
-namespace Common
+namespace Witherspoon
 {
-namespace Callout
+namespace Fault
 {
 namespace Error
 {
-    struct GPIO;
+    struct PsuErrorCode1;
 } // namespace Error
-} // namespace Callout
-} // namespace Common
-} // namespace openbmc_project
-} // namespace xyz
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
 } // namespace sdbusplus
 
 namespace sdbusplus
@@ -481,6 +481,26 @@ namespace Fault
 {
 namespace Error
 {
+    struct PsuErrorCode0;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
     struct PowerOnErrorCode30;
 } // namespace Error
 } // namespace Fault
@@ -567,6 +587,26 @@ namespace Error
 } // namespace Witherspoon
 } // namespace open_power
 } // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace xyz
+{
+namespace openbmc_project
+{
+namespace Common
+{
+namespace Callout
+{
+namespace Error
+{
+    struct GPIO;
+} // namespace Error
+} // namespace Callout
+} // namespace Common
+} // namespace openbmc_project
+} // namespace xyz
 } // namespace sdbusplus
 
 namespace sdbusplus
@@ -1208,6 +1248,44 @@ template <>
 struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnFailure>
 {
     using type = org::open_power::Witherspoon::Fault::PowerOnFailure;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PowerOnErrorCode0
+{
+
+
+}  // namespace _PowerOnErrorCode0
+
+struct PowerOnErrorCode0
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode0>
+{
+    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode0;
 };
 
 }
@@ -2588,13 +2666,13 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode0
+namespace _PsuErrorCode0
 {
 
 
-}  // namespace _PowerOnErrorCode0
+}  // namespace _PsuErrorCode0
 
-struct PowerOnErrorCode0
+struct PsuErrorCode0
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
@@ -2611,9 +2689,47 @@ namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode0>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PsuErrorCode0>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode0;
+    using type = org::open_power::Witherspoon::Fault::PsuErrorCode0;
+};
+
+}
+
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace _PsuErrorCode1
+{
+
+
+}  // namespace _PsuErrorCode1
+
+struct PsuErrorCode1
+{
+    static constexpr auto L = level::ERR;
+    using metadata_types = std::tuple<>;
+
+};
+
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+
+
+namespace details
+{
+
+template <>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PsuErrorCode1>
+{
+    using type = org::open_power::Witherspoon::Fault::PsuErrorCode1;
 };
 
 }

--- a/org/open_power/Witherspoon/Fault.errors.yaml
+++ b/org/open_power/Witherspoon/Fault.errors.yaml
@@ -24,6 +24,9 @@
 - name: PowerOnFailure
   description: System power failed to turn on
 
+- name: PowerOnErrorCode0
+  description: Read CPLD-register fail
+  
 - name: PowerOnErrorCode1
   description: Power on error reason is PSU1_PGOOD fail
 
@@ -132,8 +135,11 @@
 - name: PowerOnErrorCode36
   description: Power on error reason is PSU0&PSU1_pgood fail
 
-- name: PowerOnErrorCode0
-  description: Read CPLD-register fail
+- name: PsuErrorCode0
+  description: PSU1 power fail
+
+- name: PsuErrorCode1
+  description: PSU0 power fail
 
 - name: PowerSequencerVoltageFault
   description: The power sequencer chip detected a voltage fault

--- a/org/open_power/Witherspoon/Fault.metadata.yaml
+++ b/org/open_power/Witherspoon/Fault.metadata.yaml
@@ -163,6 +163,12 @@
 - name: PowerOnErrorCode0
   level: ERR
 
+- name: PsuErrorCode0
+  level: ERR
+
+- name: PsuErrorCode1
+  level: ERR
+
 - name: PowerSequencerVoltageFault
   level: ERR
   meta:

--- a/power-sequencer/main.cpp
+++ b/power-sequencer/main.cpp
@@ -34,7 +34,8 @@ int main(int argc, char** argv)
 
     if ((action != "pgood-monitor") &&
         (action != "mihawk-cpld-pgood-monitor") &&
-        (action != "runtime-monitor"))
+        (action != "runtime-monitor") &&
+        (action != "mihawk-cpld-runtime-monitor"))
     {
         std::cerr << "Invalid action\n";
         args.usage(argv);
@@ -73,11 +74,18 @@ int main(int argc, char** argv)
         monitor = std::make_unique<PGOODMonitor>(std::move(device), bus, event,
                                                  interval);
     }
-    else // runtime-monitor
+
+    if (action == "runtime-monitor") // runtime-monitor
     {
         // Continuously monitor this device both by polling
         // and on 'power lost' signals.
         auto device = std::make_unique<UCD90160>(0, bus);
+        monitor = std::make_unique<RuntimeMonitor>(std::move(device), bus,
+                                                   event, interval);
+    }
+    else if (action == "mihawk-cpld-runtime-monitor")
+    {
+        auto device = std::make_unique<MIHAWKCPLD>(0, bus);
         monitor = std::make_unique<RuntimeMonitor>(std::move(device), bus,
                                                    event, interval);
     }

--- a/power-sequencer/mihawk-cpld.hpp
+++ b/power-sequencer/mihawk-cpld.hpp
@@ -82,14 +82,19 @@ class MIHAWKCPLD : public Device
     bool checkPoweronFault();
 
     /**
-     * The D-Bus bus object
-     */
-    sdbusplus::bus::bus& bus;
-
-    /**
      * Clear CPLD intrupt record after reading CPLD_register.
      */
     void clearCPLDregister();
+
+    /**
+     * Check PSU power status via runtime-monitor after power_on_fault.
+     */
+    int checkPSUDCpgood();
+
+    /**
+     * The D-Bus bus object
+     */
+    sdbusplus::bus::bus& bus;
 
     /**
      * All of powerOnErrorcode are the definition of error-code

--- a/power-sequencer/pgood_monitor.cpp
+++ b/power-sequencer/pgood_monitor.cpp
@@ -67,9 +67,7 @@ void PGOODMonitor::analyze()
 
     if (pgoodPending())
     {
-#if defined UCD90160_DEVICE_ACCESS || defined MIHAWKCPLD_DEVICE_ACCESS
         device->onFailure();
-#endif
         report<PowerOnFailure>();
     }
 

--- a/power-sequencer/runtime_monitor.cpp
+++ b/power-sequencer/runtime_monitor.cpp
@@ -33,11 +33,7 @@ using namespace sdbusplus::org::open_power::Witherspoon::Fault::Error;
 
 int RuntimeMonitor::run()
 {
-#ifdef UCD90160_DEVICE_ACCESS
     return DeviceMonitor::run();
-#else
-    return EXIT_SUCCESS;
-#endif
 }
 
 void RuntimeMonitor::onPowerLost(sdbusplus::message::message& msg)
@@ -48,9 +44,8 @@ void RuntimeMonitor::onPowerLost(sdbusplus::message::message& msg)
     {
         timer.setEnabled(false);
 
-#ifdef UCD90160_DEVICE_ACCESS
         device->onFailure();
-#endif
+
         // Note: This application only runs when the system has
         // power, so it will be killed by systemd sometime shortly
         // after this power off is issued.

--- a/power-supply/power_supply.cpp
+++ b/power-supply/power_supply.cpp
@@ -676,6 +676,7 @@ void PowerSupply::updateInventory()
         {
         }
 
+#ifdef MIHAWK_PSU_NOT_ACCESS
         try
         {
             ccin = pmbusIntf.readString(CCIN, Type::HwmonDeviceDebug);
@@ -683,6 +684,7 @@ void PowerSupply::updateInventory()
         catch (ReadFailure& e)
         {
         }
+#endif
 
         try
         {
@@ -704,7 +706,9 @@ void PowerSupply::updateInventory()
 
     assetProps.emplace(SN_PROP, sn);
     assetProps.emplace(PN_PROP, pn);
+#ifdef MIHAWK_PSU_NOT_ACCESS
     assetProps.emplace(MODEL_PROP, ccin);
+#endif
     interfaces.emplace(ASSET_IFACE, std::move(assetProps));
 
     versionProps.emplace(VERSION_PROP, version);


### PR DESCRIPTION
Add runtime-action of power-sequencer for mihawk.
Check psu power status via runtime-monitor after
power_on_fault.

Fix mihawk's psu-monitor errors.
Because mihawk's psu doesn't have input_history
function, add the condition in power-supply.cpp.

Remove device flag on power-sequencer/main.cpp,
, pgood_monitor.cpp and runtime_monitor.cpp.

This version is modified for OP940.
Due to different architectures for master, so this version
has not been pushed to upstream.

Tested:
Use command "obmcutil chassiskill" to trigger PGOOD error
action analysis during chassis power on.

Signed-off-by: Andy YF Wang Andy_YF_Wang@wistron.com