### PR TITLE
Fix mihawk power-sequencer issue and update CPLD-errorcode

### DIFF
--- a/elog-errors.hpp
+++ b/elog-errors.hpp
@@ -2,12 +2,12 @@
 // See elog-gen.py for more details
 #pragma once
 
+#include <phosphor-logging/elog.hpp>
+#include <phosphor-logging/log.hpp>
+#include <sdbusplus/exception.hpp>
 #include <string>
 #include <tuple>
 #include <type_traits>
-#include <sdbusplus/exception.hpp>
-#include <phosphor-logging/log.hpp>
-#include <phosphor-logging/elog.hpp>
 
 namespace sdbusplus
 {
@@ -21,7 +21,87 @@ namespace Fault
 {
 namespace Error
 {
-    struct MemoryPowerFault;
+struct MemoryPowerFault;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct GPUPowerFault;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerSequencerPGOODFault;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerSequencerVoltageFault;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct GPUOverTemp;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -41,7 +121,7 @@ namespace Callout
 {
 namespace Error
 {
-    struct Device;
+struct IPMISensor;
 } // namespace Error
 } // namespace Callout
 } // namespace Common
@@ -61,7 +141,7 @@ namespace Fault
 {
 namespace Error
 {
-    struct PowerSequencerPGOODFault;
+struct PowerOnFailure;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -81,7 +161,7 @@ namespace Fault
 {
 namespace Error
 {
-    struct PsuErrorCode1;
+struct Shutdown;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -101,407 +181,7 @@ namespace Fault
 {
 namespace Error
 {
-    struct PowerSequencerVoltageFault;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-    struct PowerOnErrorCode10;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-    struct PowerOnErrorCode11;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-    struct PowerOnErrorCode12;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-    struct PowerOnErrorCode13;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-    struct PowerOnFailure;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-    struct PowerOnErrorCode15;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-    struct PowerOnErrorCode16;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-    struct PowerOnErrorCode17;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-    struct PowerOnErrorCode18;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-    struct PowerOnErrorCode19;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-    struct Shutdown;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-    struct PowerOnErrorCode31;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-    struct PowerOnErrorCode36;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-    struct PowerOnErrorCode34;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-    struct PowerOnErrorCode35;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-    struct PowerSupplyTemperatureFault;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-    struct PowerSupplyFanFault;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-    struct PowerSupplyShouldBeOn;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-    struct PsuErrorCode0;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-    struct PowerOnErrorCode30;
+struct PowerSupplyInputFault;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -521,7 +201,7 @@ namespace Callout
 {
 namespace Error
 {
-    struct IIC;
+struct Device;
 } // namespace Error
 } // namespace Callout
 } // namespace Common
@@ -541,7 +221,7 @@ namespace Fault
 {
 namespace Error
 {
-    struct PowerSupplyOutputOvercurrent;
+struct ErrorCode15;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -561,7 +241,7 @@ namespace Fault
 {
 namespace Error
 {
-    struct PowerSupplyInputFault;
+struct ErrorCode14;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -581,7 +261,247 @@ namespace Fault
 {
 namespace Error
 {
-    struct PowerOnErrorCode14;
+struct ErrorCode17;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct ErrorCode16;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct ErrorCode11;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct ErrorCode10;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct ErrorCode13;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct ErrorCode12;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct ErrorCode36;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct ErrorCode35;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct ErrorCode34;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct ErrorCode19;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct ErrorCode18;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct ErrorCode31;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct ErrorCode30;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -601,7 +521,7 @@ namespace Callout
 {
 namespace Error
 {
-    struct GPIO;
+struct GPIO;
 } // namespace Error
 } // namespace Callout
 } // namespace Common
@@ -621,7 +541,7 @@ namespace Callout
 {
 namespace Error
 {
-    struct IPMISensor;
+struct IIC;
 } // namespace Error
 } // namespace Callout
 } // namespace Common
@@ -641,7 +561,7 @@ namespace Fault
 {
 namespace Error
 {
-    struct PowerSequencerFault;
+struct ErrorCode32;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -661,7 +581,7 @@ namespace Fault
 {
 namespace Error
 {
-    struct GPUOverTemp;
+struct PowerSupplyOutputOvercurrent;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -681,7 +601,7 @@ namespace Fault
 {
 namespace Error
 {
-    struct PowerOnErrorCode29;
+struct ErrorCode33;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -701,7 +621,7 @@ namespace Fault
 {
 namespace Error
 {
-    struct PowerOnErrorCode28;
+struct PowerSupplyTemperatureFault;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -721,7 +641,87 @@ namespace Fault
 {
 namespace Error
 {
-    struct PowerSupplyOutputOvervoltage;
+struct PowerSequencerFault;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerSupplyFanFault;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct PowerSupplyOutputOvervoltage;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct ErrorCode9;
+} // namespace Error
+} // namespace Fault
+} // namespace Witherspoon
+} // namespace open_power
+} // namespace org
+} // namespace sdbusplus
+
+namespace sdbusplus
+{
+namespace org
+{
+namespace open_power
+{
+namespace Witherspoon
+{
+namespace Fault
+{
+namespace Error
+{
+struct ErrorCode8;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -741,7 +741,7 @@ namespace Callout
 {
 namespace Error
 {
-    struct Inventory;
+struct Inventory;
 } // namespace Error
 } // namespace Callout
 } // namespace Common
@@ -761,7 +761,7 @@ namespace Fault
 {
 namespace Error
 {
-    struct PowerOnErrorCode21;
+struct ErrorCode5;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -781,7 +781,7 @@ namespace Fault
 {
 namespace Error
 {
-    struct PowerOnErrorCode20;
+struct ErrorCode4;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -801,7 +801,7 @@ namespace Fault
 {
 namespace Error
 {
-    struct PowerOnErrorCode23;
+struct ErrorCode7;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -821,7 +821,7 @@ namespace Fault
 {
 namespace Error
 {
-    struct PowerOnErrorCode22;
+struct ErrorCode6;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -841,7 +841,7 @@ namespace Fault
 {
 namespace Error
 {
-    struct PowerOnErrorCode25;
+struct ErrorCode1;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -861,7 +861,7 @@ namespace Fault
 {
 namespace Error
 {
-    struct PowerOnErrorCode24;
+struct ErrorCode0;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -881,7 +881,7 @@ namespace Fault
 {
 namespace Error
 {
-    struct PowerOnErrorCode27;
+struct ErrorCode3;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -901,7 +901,7 @@ namespace Fault
 {
 namespace Error
 {
-    struct PowerOnErrorCode26;
+struct ErrorCode2;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -921,7 +921,7 @@ namespace Fault
 {
 namespace Error
 {
-    struct PowerOnErrorCode32;
+struct ErrorCode28;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -941,7 +941,7 @@ namespace Fault
 {
 namespace Error
 {
-    struct PowerOnErrorCode8;
+struct ErrorCode29;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -961,7 +961,7 @@ namespace Fault
 {
 namespace Error
 {
-    struct PowerOnErrorCode9;
+struct PowerSupplyShouldBeOn;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -981,7 +981,7 @@ namespace Fault
 {
 namespace Error
 {
-    struct GPUPowerFault;
+struct ErrorCode20;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -1001,7 +1001,7 @@ namespace Fault
 {
 namespace Error
 {
-    struct PowerOnErrorCode33;
+struct ErrorCode21;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -1021,7 +1021,7 @@ namespace Fault
 {
 namespace Error
 {
-    struct PowerOnErrorCode2;
+struct ErrorCode22;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -1041,7 +1041,7 @@ namespace Fault
 {
 namespace Error
 {
-    struct PowerOnErrorCode3;
+struct ErrorCode23;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -1061,7 +1061,7 @@ namespace Fault
 {
 namespace Error
 {
-    struct PowerOnErrorCode0;
+struct ErrorCode24;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -1081,7 +1081,7 @@ namespace Fault
 {
 namespace Error
 {
-    struct PowerOnErrorCode1;
+struct ErrorCode25;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -1101,7 +1101,7 @@ namespace Fault
 {
 namespace Error
 {
-    struct PowerOnErrorCode6;
+struct ErrorCode26;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
@@ -1121,54 +1121,13 @@ namespace Fault
 {
 namespace Error
 {
-    struct PowerOnErrorCode7;
+struct ErrorCode27;
 } // namespace Error
 } // namespace Fault
 } // namespace Witherspoon
 } // namespace open_power
 } // namespace org
 } // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-    struct PowerOnErrorCode4;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
-namespace sdbusplus
-{
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace Error
-{
-    struct PowerOnErrorCode5;
-} // namespace Error
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-} // namespace sdbusplus
-
 
 namespace phosphor
 {
@@ -1187,14 +1146,12 @@ namespace Fault
 namespace _Shutdown
 {
 
-
-}  // namespace _Shutdown
+} // namespace _Shutdown
 
 struct Shutdown
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -1202,17 +1159,17 @@ struct Shutdown
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::Shutdown>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::Shutdown>
 {
     using type = org::open_power::Witherspoon::Fault::Shutdown;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -1225,14 +1182,12 @@ namespace Fault
 namespace _PowerOnFailure
 {
 
-
-}  // namespace _PowerOnFailure
+} // namespace _PowerOnFailure
 
 struct PowerOnFailure
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -1240,17 +1195,17 @@ struct PowerOnFailure
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnFailure>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnFailure>
 {
     using type = org::open_power::Witherspoon::Fault::PowerOnFailure;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -1260,17 +1215,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode0
+namespace _ErrorCode0
 {
 
+} // namespace _ErrorCode0
 
-}  // namespace _PowerOnErrorCode0
-
-struct PowerOnErrorCode0
+struct ErrorCode0
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -1278,17 +1231,17 @@ struct PowerOnErrorCode0
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode0>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode0>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode0;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode0;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -1298,17 +1251,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode1
+namespace _ErrorCode1
 {
 
+} // namespace _ErrorCode1
 
-}  // namespace _PowerOnErrorCode1
-
-struct PowerOnErrorCode1
+struct ErrorCode1
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -1316,17 +1267,17 @@ struct PowerOnErrorCode1
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode1>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode1>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode1;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode1;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -1336,17 +1287,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode2
+namespace _ErrorCode2
 {
 
+} // namespace _ErrorCode2
 
-}  // namespace _PowerOnErrorCode2
-
-struct PowerOnErrorCode2
+struct ErrorCode2
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -1354,17 +1303,17 @@ struct PowerOnErrorCode2
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode2>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode2>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode2;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode2;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -1374,17 +1323,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode3
+namespace _ErrorCode3
 {
 
+} // namespace _ErrorCode3
 
-}  // namespace _PowerOnErrorCode3
-
-struct PowerOnErrorCode3
+struct ErrorCode3
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -1392,17 +1339,17 @@ struct PowerOnErrorCode3
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode3>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode3>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode3;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode3;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -1412,17 +1359,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode4
+namespace _ErrorCode4
 {
 
+} // namespace _ErrorCode4
 
-}  // namespace _PowerOnErrorCode4
-
-struct PowerOnErrorCode4
+struct ErrorCode4
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -1430,17 +1375,17 @@ struct PowerOnErrorCode4
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode4>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode4>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode4;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode4;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -1450,17 +1395,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode5
+namespace _ErrorCode5
 {
 
+} // namespace _ErrorCode5
 
-}  // namespace _PowerOnErrorCode5
-
-struct PowerOnErrorCode5
+struct ErrorCode5
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -1468,17 +1411,17 @@ struct PowerOnErrorCode5
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode5>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode5>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode5;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode5;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -1488,17 +1431,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode6
+namespace _ErrorCode6
 {
 
+} // namespace _ErrorCode6
 
-}  // namespace _PowerOnErrorCode6
-
-struct PowerOnErrorCode6
+struct ErrorCode6
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -1506,17 +1447,17 @@ struct PowerOnErrorCode6
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode6>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode6>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode6;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode6;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -1526,17 +1467,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode7
+namespace _ErrorCode7
 {
 
+} // namespace _ErrorCode7
 
-}  // namespace _PowerOnErrorCode7
-
-struct PowerOnErrorCode7
+struct ErrorCode7
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -1544,17 +1483,17 @@ struct PowerOnErrorCode7
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode7>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode7>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode7;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode7;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -1564,17 +1503,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode8
+namespace _ErrorCode8
 {
 
+} // namespace _ErrorCode8
 
-}  // namespace _PowerOnErrorCode8
-
-struct PowerOnErrorCode8
+struct ErrorCode8
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -1582,17 +1519,17 @@ struct PowerOnErrorCode8
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode8>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode8>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode8;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode8;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -1602,17 +1539,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode9
+namespace _ErrorCode9
 {
 
+} // namespace _ErrorCode9
 
-}  // namespace _PowerOnErrorCode9
-
-struct PowerOnErrorCode9
+struct ErrorCode9
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -1620,17 +1555,17 @@ struct PowerOnErrorCode9
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode9>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode9>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode9;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode9;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -1640,17 +1575,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode10
+namespace _ErrorCode10
 {
 
+} // namespace _ErrorCode10
 
-}  // namespace _PowerOnErrorCode10
-
-struct PowerOnErrorCode10
+struct ErrorCode10
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -1658,17 +1591,17 @@ struct PowerOnErrorCode10
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode10>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode10>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode10;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode10;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -1678,17 +1611,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode11
+namespace _ErrorCode11
 {
 
+} // namespace _ErrorCode11
 
-}  // namespace _PowerOnErrorCode11
-
-struct PowerOnErrorCode11
+struct ErrorCode11
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -1696,17 +1627,17 @@ struct PowerOnErrorCode11
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode11>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode11>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode11;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode11;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -1716,17 +1647,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode12
+namespace _ErrorCode12
 {
 
+} // namespace _ErrorCode12
 
-}  // namespace _PowerOnErrorCode12
-
-struct PowerOnErrorCode12
+struct ErrorCode12
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -1734,17 +1663,17 @@ struct PowerOnErrorCode12
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode12>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode12>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode12;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode12;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -1754,17 +1683,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode13
+namespace _ErrorCode13
 {
 
+} // namespace _ErrorCode13
 
-}  // namespace _PowerOnErrorCode13
-
-struct PowerOnErrorCode13
+struct ErrorCode13
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -1772,17 +1699,17 @@ struct PowerOnErrorCode13
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode13>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode13>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode13;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode13;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -1792,17 +1719,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode14
+namespace _ErrorCode14
 {
 
+} // namespace _ErrorCode14
 
-}  // namespace _PowerOnErrorCode14
-
-struct PowerOnErrorCode14
+struct ErrorCode14
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -1810,17 +1735,17 @@ struct PowerOnErrorCode14
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode14>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode14>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode14;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode14;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -1830,17 +1755,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode15
+namespace _ErrorCode15
 {
 
+} // namespace _ErrorCode15
 
-}  // namespace _PowerOnErrorCode15
-
-struct PowerOnErrorCode15
+struct ErrorCode15
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -1848,17 +1771,17 @@ struct PowerOnErrorCode15
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode15>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode15>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode15;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode15;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -1868,17 +1791,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode16
+namespace _ErrorCode16
 {
 
+} // namespace _ErrorCode16
 
-}  // namespace _PowerOnErrorCode16
-
-struct PowerOnErrorCode16
+struct ErrorCode16
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -1886,17 +1807,17 @@ struct PowerOnErrorCode16
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode16>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode16>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode16;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode16;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -1906,17 +1827,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode17
+namespace _ErrorCode17
 {
 
+} // namespace _ErrorCode17
 
-}  // namespace _PowerOnErrorCode17
-
-struct PowerOnErrorCode17
+struct ErrorCode17
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -1924,17 +1843,17 @@ struct PowerOnErrorCode17
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode17>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode17>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode17;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode17;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -1944,17 +1863,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode18
+namespace _ErrorCode18
 {
 
+} // namespace _ErrorCode18
 
-}  // namespace _PowerOnErrorCode18
-
-struct PowerOnErrorCode18
+struct ErrorCode18
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -1962,17 +1879,17 @@ struct PowerOnErrorCode18
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode18>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode18>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode18;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode18;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -1982,17 +1899,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode19
+namespace _ErrorCode19
 {
 
+} // namespace _ErrorCode19
 
-}  // namespace _PowerOnErrorCode19
-
-struct PowerOnErrorCode19
+struct ErrorCode19
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -2000,17 +1915,17 @@ struct PowerOnErrorCode19
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode19>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode19>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode19;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode19;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -2020,17 +1935,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode20
+namespace _ErrorCode20
 {
 
+} // namespace _ErrorCode20
 
-}  // namespace _PowerOnErrorCode20
-
-struct PowerOnErrorCode20
+struct ErrorCode20
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -2038,17 +1951,17 @@ struct PowerOnErrorCode20
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode20>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode20>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode20;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode20;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -2058,17 +1971,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode21
+namespace _ErrorCode21
 {
 
+} // namespace _ErrorCode21
 
-}  // namespace _PowerOnErrorCode21
-
-struct PowerOnErrorCode21
+struct ErrorCode21
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -2076,17 +1987,17 @@ struct PowerOnErrorCode21
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode21>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode21>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode21;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode21;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -2096,17 +2007,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode22
+namespace _ErrorCode22
 {
 
+} // namespace _ErrorCode22
 
-}  // namespace _PowerOnErrorCode22
-
-struct PowerOnErrorCode22
+struct ErrorCode22
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -2114,17 +2023,17 @@ struct PowerOnErrorCode22
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode22>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode22>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode22;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode22;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -2134,17 +2043,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode23
+namespace _ErrorCode23
 {
 
+} // namespace _ErrorCode23
 
-}  // namespace _PowerOnErrorCode23
-
-struct PowerOnErrorCode23
+struct ErrorCode23
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -2152,17 +2059,17 @@ struct PowerOnErrorCode23
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode23>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode23>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode23;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode23;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -2172,17 +2079,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode24
+namespace _ErrorCode24
 {
 
+} // namespace _ErrorCode24
 
-}  // namespace _PowerOnErrorCode24
-
-struct PowerOnErrorCode24
+struct ErrorCode24
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -2190,17 +2095,17 @@ struct PowerOnErrorCode24
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode24>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode24>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode24;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode24;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -2210,17 +2115,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode25
+namespace _ErrorCode25
 {
 
+} // namespace _ErrorCode25
 
-}  // namespace _PowerOnErrorCode25
-
-struct PowerOnErrorCode25
+struct ErrorCode25
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -2228,17 +2131,17 @@ struct PowerOnErrorCode25
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode25>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode25>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode25;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode25;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -2248,17 +2151,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode26
+namespace _ErrorCode26
 {
 
+} // namespace _ErrorCode26
 
-}  // namespace _PowerOnErrorCode26
-
-struct PowerOnErrorCode26
+struct ErrorCode26
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -2266,17 +2167,17 @@ struct PowerOnErrorCode26
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode26>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode26>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode26;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode26;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -2286,17 +2187,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode27
+namespace _ErrorCode27
 {
 
+} // namespace _ErrorCode27
 
-}  // namespace _PowerOnErrorCode27
-
-struct PowerOnErrorCode27
+struct ErrorCode27
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -2304,17 +2203,17 @@ struct PowerOnErrorCode27
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode27>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode27>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode27;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode27;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -2324,17 +2223,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode28
+namespace _ErrorCode28
 {
 
+} // namespace _ErrorCode28
 
-}  // namespace _PowerOnErrorCode28
-
-struct PowerOnErrorCode28
+struct ErrorCode28
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -2342,17 +2239,17 @@ struct PowerOnErrorCode28
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode28>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode28>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode28;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode28;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -2362,17 +2259,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode29
+namespace _ErrorCode29
 {
 
+} // namespace _ErrorCode29
 
-}  // namespace _PowerOnErrorCode29
-
-struct PowerOnErrorCode29
+struct ErrorCode29
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -2380,17 +2275,17 @@ struct PowerOnErrorCode29
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode29>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode29>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode29;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode29;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -2400,17 +2295,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode30
+namespace _ErrorCode30
 {
 
+} // namespace _ErrorCode30
 
-}  // namespace _PowerOnErrorCode30
-
-struct PowerOnErrorCode30
+struct ErrorCode30
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -2418,17 +2311,17 @@ struct PowerOnErrorCode30
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode30>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode30>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode30;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode30;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -2438,17 +2331,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode31
+namespace _ErrorCode31
 {
 
+} // namespace _ErrorCode31
 
-}  // namespace _PowerOnErrorCode31
-
-struct PowerOnErrorCode31
+struct ErrorCode31
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -2456,17 +2347,17 @@ struct PowerOnErrorCode31
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode31>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode31>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode31;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode31;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -2476,17 +2367,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode32
+namespace _ErrorCode32
 {
 
+} // namespace _ErrorCode32
 
-}  // namespace _PowerOnErrorCode32
-
-struct PowerOnErrorCode32
+struct ErrorCode32
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -2494,17 +2383,17 @@ struct PowerOnErrorCode32
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode32>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode32>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode32;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode32;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -2514,17 +2403,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode33
+namespace _ErrorCode33
 {
 
+} // namespace _ErrorCode33
 
-}  // namespace _PowerOnErrorCode33
-
-struct PowerOnErrorCode33
+struct ErrorCode33
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -2532,17 +2419,17 @@ struct PowerOnErrorCode33
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode33>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode33>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode33;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode33;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -2552,17 +2439,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode34
+namespace _ErrorCode34
 {
 
+} // namespace _ErrorCode34
 
-}  // namespace _PowerOnErrorCode34
-
-struct PowerOnErrorCode34
+struct ErrorCode34
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -2570,17 +2455,17 @@ struct PowerOnErrorCode34
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode34>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode34>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode34;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode34;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -2590,17 +2475,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode35
+namespace _ErrorCode35
 {
 
+} // namespace _ErrorCode35
 
-}  // namespace _PowerOnErrorCode35
-
-struct PowerOnErrorCode35
+struct ErrorCode35
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -2608,17 +2491,17 @@ struct PowerOnErrorCode35
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode35>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode35>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode35;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode35;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -2628,17 +2511,15 @@ namespace Witherspoon
 {
 namespace Fault
 {
-namespace _PowerOnErrorCode36
+namespace _ErrorCode36
 {
 
+} // namespace _ErrorCode36
 
-}  // namespace _PowerOnErrorCode36
-
-struct PowerOnErrorCode36
+struct ErrorCode36
 {
     static constexpr auto L = level::ERR;
     using metadata_types = std::tuple<>;
-
 };
 
 } // namespace Fault
@@ -2646,93 +2527,17 @@ struct PowerOnErrorCode36
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerOnErrorCode36>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::ErrorCode36>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerOnErrorCode36;
+    using type = org::open_power::Witherspoon::Fault::ErrorCode36;
 };
 
-}
-
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace _PsuErrorCode0
-{
-
-
-}  // namespace _PsuErrorCode0
-
-struct PsuErrorCode0
-{
-    static constexpr auto L = level::ERR;
-    using metadata_types = std::tuple<>;
-
-};
-
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-
-
-namespace details
-{
-
-template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PsuErrorCode0>
-{
-    using type = org::open_power::Witherspoon::Fault::PsuErrorCode0;
-};
-
-}
-
-namespace org
-{
-namespace open_power
-{
-namespace Witherspoon
-{
-namespace Fault
-{
-namespace _PsuErrorCode1
-{
-
-
-}  // namespace _PsuErrorCode1
-
-struct PsuErrorCode1
-{
-    static constexpr auto L = level::ERR;
-    using metadata_types = std::tuple<>;
-
-};
-
-} // namespace Fault
-} // namespace Witherspoon
-} // namespace open_power
-} // namespace org
-
-
-namespace details
-{
-
-template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PsuErrorCode1>
-{
-    using type = org::open_power::Witherspoon::Fault::PsuErrorCode1;
-};
-
-}
+} // namespace details
 
 namespace org
 {
@@ -2753,8 +2558,8 @@ struct RAIL
      * mako template lookups.
      */
     static constexpr auto str_short = "RAIL";
-    using type = std::tuple<std::decay_t<decltype("RAIL=%d")>,uint16_t>;
-    explicit constexpr RAIL(uint16_t a) : _entry(entry("RAIL=%d", a)) {};
+    using type = std::tuple<std::decay_t<decltype("RAIL=%d")>, uint16_t>;
+    explicit constexpr RAIL(uint16_t a) : _entry(entry("RAIL=%d", a)){};
     type _entry;
 };
 struct RAIL_NAME
@@ -2765,8 +2570,10 @@ struct RAIL_NAME
      * mako template lookups.
      */
     static constexpr auto str_short = "RAIL_NAME";
-    using type = std::tuple<std::decay_t<decltype("RAIL_NAME=%s")>,const char*>;
-    explicit constexpr RAIL_NAME(const char* a) : _entry(entry("RAIL_NAME=%s", a)) {};
+    using type =
+        std::tuple<std::decay_t<decltype("RAIL_NAME=%s")>, const char*>;
+    explicit constexpr RAIL_NAME(const char* a) :
+        _entry(entry("RAIL_NAME=%s", a)){};
     type _entry;
 };
 struct RAW_STATUS
@@ -2777,12 +2584,14 @@ struct RAW_STATUS
      * mako template lookups.
      */
     static constexpr auto str_short = "RAW_STATUS";
-    using type = std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>,const char*>;
-    explicit constexpr RAW_STATUS(const char* a) : _entry(entry("RAW_STATUS=%s", a)) {};
+    using type =
+        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
+    explicit constexpr RAW_STATUS(const char* a) :
+        _entry(entry("RAW_STATUS=%s", a)){};
     type _entry;
 };
 
-}  // namespace _PowerSequencerVoltageFault
+} // namespace _PowerSequencerVoltageFault
 
 struct PowerSequencerVoltageFault
 {
@@ -2791,7 +2600,6 @@ struct PowerSequencerVoltageFault
     using RAIL_NAME = _PowerSequencerVoltageFault::RAIL_NAME;
     using RAW_STATUS = _PowerSequencerVoltageFault::RAW_STATUS;
     using metadata_types = std::tuple<RAIL, RAIL_NAME, RAW_STATUS>;
-
 };
 
 } // namespace Fault
@@ -2799,17 +2607,18 @@ struct PowerSequencerVoltageFault
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerSequencerVoltageFault>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerSequencerVoltageFault>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerSequencerVoltageFault;
+    using type =
+        org::open_power::Witherspoon::Fault::PowerSequencerVoltageFault;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -2830,8 +2639,9 @@ struct INPUT_NUM
      * mako template lookups.
      */
     static constexpr auto str_short = "INPUT_NUM";
-    using type = std::tuple<std::decay_t<decltype("INPUT_NUM=%d")>,uint16_t>;
-    explicit constexpr INPUT_NUM(uint16_t a) : _entry(entry("INPUT_NUM=%d", a)) {};
+    using type = std::tuple<std::decay_t<decltype("INPUT_NUM=%d")>, uint16_t>;
+    explicit constexpr INPUT_NUM(uint16_t a) :
+        _entry(entry("INPUT_NUM=%d", a)){};
     type _entry;
 };
 struct INPUT_NAME
@@ -2842,8 +2652,10 @@ struct INPUT_NAME
      * mako template lookups.
      */
     static constexpr auto str_short = "INPUT_NAME";
-    using type = std::tuple<std::decay_t<decltype("INPUT_NAME=%s")>,const char*>;
-    explicit constexpr INPUT_NAME(const char* a) : _entry(entry("INPUT_NAME=%s", a)) {};
+    using type =
+        std::tuple<std::decay_t<decltype("INPUT_NAME=%s")>, const char*>;
+    explicit constexpr INPUT_NAME(const char* a) :
+        _entry(entry("INPUT_NAME=%s", a)){};
     type _entry;
 };
 struct RAW_STATUS
@@ -2854,12 +2666,14 @@ struct RAW_STATUS
      * mako template lookups.
      */
     static constexpr auto str_short = "RAW_STATUS";
-    using type = std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>,const char*>;
-    explicit constexpr RAW_STATUS(const char* a) : _entry(entry("RAW_STATUS=%s", a)) {};
+    using type =
+        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
+    explicit constexpr RAW_STATUS(const char* a) :
+        _entry(entry("RAW_STATUS=%s", a)){};
     type _entry;
 };
 
-}  // namespace _PowerSequencerPGOODFault
+} // namespace _PowerSequencerPGOODFault
 
 struct PowerSequencerPGOODFault
 {
@@ -2868,7 +2682,6 @@ struct PowerSequencerPGOODFault
     using INPUT_NAME = _PowerSequencerPGOODFault::INPUT_NAME;
     using RAW_STATUS = _PowerSequencerPGOODFault::RAW_STATUS;
     using metadata_types = std::tuple<INPUT_NUM, INPUT_NAME, RAW_STATUS>;
-
 };
 
 } // namespace Fault
@@ -2876,17 +2689,17 @@ struct PowerSequencerPGOODFault
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerSequencerPGOODFault>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerSequencerPGOODFault>
 {
     using type = org::open_power::Witherspoon::Fault::PowerSequencerPGOODFault;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -2907,19 +2720,20 @@ struct RAW_STATUS
      * mako template lookups.
      */
     static constexpr auto str_short = "RAW_STATUS";
-    using type = std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>,const char*>;
-    explicit constexpr RAW_STATUS(const char* a) : _entry(entry("RAW_STATUS=%s", a)) {};
+    using type =
+        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
+    explicit constexpr RAW_STATUS(const char* a) :
+        _entry(entry("RAW_STATUS=%s", a)){};
     type _entry;
 };
 
-}  // namespace _PowerSequencerFault
+} // namespace _PowerSequencerFault
 
 struct PowerSequencerFault
 {
     static constexpr auto L = level::ERR;
     using RAW_STATUS = _PowerSequencerFault::RAW_STATUS;
     using metadata_types = std::tuple<RAW_STATUS>;
-
 };
 
 } // namespace Fault
@@ -2927,17 +2741,17 @@ struct PowerSequencerFault
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerSequencerFault>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerSequencerFault>
 {
     using type = org::open_power::Witherspoon::Fault::PowerSequencerFault;
 };
 
-}
+} // namespace details
 
 namespace xyz
 {
@@ -2958,8 +2772,10 @@ struct CALLOUT_ERRNO
      * mako template lookups.
      */
     static constexpr auto str_short = "CALLOUT_ERRNO";
-    using type = std::tuple<std::decay_t<decltype("CALLOUT_ERRNO=%d")>,int32_t>;
-    explicit constexpr CALLOUT_ERRNO(int32_t a) : _entry(entry("CALLOUT_ERRNO=%d", a)) {};
+    using type =
+        std::tuple<std::decay_t<decltype("CALLOUT_ERRNO=%d")>, int32_t>;
+    explicit constexpr CALLOUT_ERRNO(int32_t a) :
+        _entry(entry("CALLOUT_ERRNO=%d", a)){};
     type _entry;
 };
 struct CALLOUT_DEVICE_PATH
@@ -2970,12 +2786,14 @@ struct CALLOUT_DEVICE_PATH
      * mako template lookups.
      */
     static constexpr auto str_short = "CALLOUT_DEVICE_PATH";
-    using type = std::tuple<std::decay_t<decltype("CALLOUT_DEVICE_PATH=%s")>,const char*>;
-    explicit constexpr CALLOUT_DEVICE_PATH(const char* a) : _entry(entry("CALLOUT_DEVICE_PATH=%s", a)) {};
+    using type = std::tuple<std::decay_t<decltype("CALLOUT_DEVICE_PATH=%s")>,
+                            const char*>;
+    explicit constexpr CALLOUT_DEVICE_PATH(const char* a) :
+        _entry(entry("CALLOUT_DEVICE_PATH=%s", a)){};
     type _entry;
 };
 
-}  // namespace _Device
+} // namespace _Device
 
 struct Device
 {
@@ -2983,7 +2801,6 @@ struct Device
     using CALLOUT_ERRNO = _Device::CALLOUT_ERRNO;
     using CALLOUT_DEVICE_PATH = _Device::CALLOUT_DEVICE_PATH;
     using metadata_types = std::tuple<CALLOUT_ERRNO, CALLOUT_DEVICE_PATH>;
-
 };
 
 } // namespace Callout
@@ -2991,17 +2808,17 @@ struct Device
 } // namespace openbmc_project
 } // namespace xyz
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::xyz::openbmc_project::Common::Callout::Error::Device>
+struct map_exception_type<
+    sdbusplus::xyz::openbmc_project::Common::Callout::Error::Device>
 {
     using type = xyz::openbmc_project::Common::Callout::Device;
 };
 
-}
+} // namespace details
 
 namespace xyz
 {
@@ -3022,21 +2839,25 @@ struct CALLOUT_GPIO_NUM
      * mako template lookups.
      */
     static constexpr auto str_short = "CALLOUT_GPIO_NUM";
-    using type = std::tuple<std::decay_t<decltype("CALLOUT_GPIO_NUM=%u")>,uint32_t>;
-    explicit constexpr CALLOUT_GPIO_NUM(uint32_t a) : _entry(entry("CALLOUT_GPIO_NUM=%u", a)) {};
+    using type =
+        std::tuple<std::decay_t<decltype("CALLOUT_GPIO_NUM=%u")>, uint32_t>;
+    explicit constexpr CALLOUT_GPIO_NUM(uint32_t a) :
+        _entry(entry("CALLOUT_GPIO_NUM=%u", a)){};
     type _entry;
 };
 
-}  // namespace _GPIO
+} // namespace _GPIO
 
 struct GPIO
 {
     static constexpr auto L = level::ERR;
     using CALLOUT_GPIO_NUM = _GPIO::CALLOUT_GPIO_NUM;
-    using CALLOUT_ERRNO = xyz::openbmc_project::Common::Callout::Device::CALLOUT_ERRNO;
-    using CALLOUT_DEVICE_PATH = xyz::openbmc_project::Common::Callout::Device::CALLOUT_DEVICE_PATH;
-    using metadata_types = std::tuple<CALLOUT_GPIO_NUM, CALLOUT_ERRNO, CALLOUT_DEVICE_PATH>;
-
+    using CALLOUT_ERRNO =
+        xyz::openbmc_project::Common::Callout::Device::CALLOUT_ERRNO;
+    using CALLOUT_DEVICE_PATH =
+        xyz::openbmc_project::Common::Callout::Device::CALLOUT_DEVICE_PATH;
+    using metadata_types =
+        std::tuple<CALLOUT_GPIO_NUM, CALLOUT_ERRNO, CALLOUT_DEVICE_PATH>;
 };
 
 } // namespace Callout
@@ -3044,17 +2865,17 @@ struct GPIO
 } // namespace openbmc_project
 } // namespace xyz
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::xyz::openbmc_project::Common::Callout::Error::GPIO>
+struct map_exception_type<
+    sdbusplus::xyz::openbmc_project::Common::Callout::Error::GPIO>
 {
     using type = xyz::openbmc_project::Common::Callout::GPIO;
 };
 
-}
+} // namespace details
 
 namespace xyz
 {
@@ -3075,8 +2896,10 @@ struct CALLOUT_IIC_BUS
      * mako template lookups.
      */
     static constexpr auto str_short = "CALLOUT_IIC_BUS";
-    using type = std::tuple<std::decay_t<decltype("CALLOUT_IIC_BUS=%s")>,const char*>;
-    explicit constexpr CALLOUT_IIC_BUS(const char* a) : _entry(entry("CALLOUT_IIC_BUS=%s", a)) {};
+    using type =
+        std::tuple<std::decay_t<decltype("CALLOUT_IIC_BUS=%s")>, const char*>;
+    explicit constexpr CALLOUT_IIC_BUS(const char* a) :
+        _entry(entry("CALLOUT_IIC_BUS=%s", a)){};
     type _entry;
 };
 struct CALLOUT_IIC_ADDR
@@ -3087,22 +2910,26 @@ struct CALLOUT_IIC_ADDR
      * mako template lookups.
      */
     static constexpr auto str_short = "CALLOUT_IIC_ADDR";
-    using type = std::tuple<std::decay_t<decltype("CALLOUT_IIC_ADDR=0x%hx")>,uint16_t>;
-    explicit constexpr CALLOUT_IIC_ADDR(uint16_t a) : _entry(entry("CALLOUT_IIC_ADDR=0x%hx", a)) {};
+    using type =
+        std::tuple<std::decay_t<decltype("CALLOUT_IIC_ADDR=0x%hx")>, uint16_t>;
+    explicit constexpr CALLOUT_IIC_ADDR(uint16_t a) :
+        _entry(entry("CALLOUT_IIC_ADDR=0x%hx", a)){};
     type _entry;
 };
 
-}  // namespace _IIC
+} // namespace _IIC
 
 struct IIC
 {
     static constexpr auto L = level::ERR;
     using CALLOUT_IIC_BUS = _IIC::CALLOUT_IIC_BUS;
     using CALLOUT_IIC_ADDR = _IIC::CALLOUT_IIC_ADDR;
-    using CALLOUT_ERRNO = xyz::openbmc_project::Common::Callout::Device::CALLOUT_ERRNO;
-    using CALLOUT_DEVICE_PATH = xyz::openbmc_project::Common::Callout::Device::CALLOUT_DEVICE_PATH;
-    using metadata_types = std::tuple<CALLOUT_IIC_BUS, CALLOUT_IIC_ADDR, CALLOUT_ERRNO, CALLOUT_DEVICE_PATH>;
-
+    using CALLOUT_ERRNO =
+        xyz::openbmc_project::Common::Callout::Device::CALLOUT_ERRNO;
+    using CALLOUT_DEVICE_PATH =
+        xyz::openbmc_project::Common::Callout::Device::CALLOUT_DEVICE_PATH;
+    using metadata_types = std::tuple<CALLOUT_IIC_BUS, CALLOUT_IIC_ADDR,
+                                      CALLOUT_ERRNO, CALLOUT_DEVICE_PATH>;
 };
 
 } // namespace Callout
@@ -3110,17 +2937,17 @@ struct IIC
 } // namespace openbmc_project
 } // namespace xyz
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::xyz::openbmc_project::Common::Callout::Error::IIC>
+struct map_exception_type<
+    sdbusplus::xyz::openbmc_project::Common::Callout::Error::IIC>
 {
     using type = xyz::openbmc_project::Common::Callout::IIC;
 };
 
-}
+} // namespace details
 
 namespace xyz
 {
@@ -3141,19 +2968,20 @@ struct CALLOUT_INVENTORY_PATH
      * mako template lookups.
      */
     static constexpr auto str_short = "CALLOUT_INVENTORY_PATH";
-    using type = std::tuple<std::decay_t<decltype("CALLOUT_INVENTORY_PATH=%s")>,const char*>;
-    explicit constexpr CALLOUT_INVENTORY_PATH(const char* a) : _entry(entry("CALLOUT_INVENTORY_PATH=%s", a)) {};
+    using type = std::tuple<std::decay_t<decltype("CALLOUT_INVENTORY_PATH=%s")>,
+                            const char*>;
+    explicit constexpr CALLOUT_INVENTORY_PATH(const char* a) :
+        _entry(entry("CALLOUT_INVENTORY_PATH=%s", a)){};
     type _entry;
 };
 
-}  // namespace _Inventory
+} // namespace _Inventory
 
 struct Inventory
 {
     static constexpr auto L = level::ERR;
     using CALLOUT_INVENTORY_PATH = _Inventory::CALLOUT_INVENTORY_PATH;
     using metadata_types = std::tuple<CALLOUT_INVENTORY_PATH>;
-
 };
 
 } // namespace Callout
@@ -3161,17 +2989,17 @@ struct Inventory
 } // namespace openbmc_project
 } // namespace xyz
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::xyz::openbmc_project::Common::Callout::Error::Inventory>
+struct map_exception_type<
+    sdbusplus::xyz::openbmc_project::Common::Callout::Error::Inventory>
 {
     using type = xyz::openbmc_project::Common::Callout::Inventory;
 };
 
-}
+} // namespace details
 
 namespace xyz
 {
@@ -3192,19 +3020,21 @@ struct CALLOUT_IPMI_SENSOR_NUM
      * mako template lookups.
      */
     static constexpr auto str_short = "CALLOUT_IPMI_SENSOR_NUM";
-    using type = std::tuple<std::decay_t<decltype("CALLOUT_IPMI_SENSOR_NUM=%u")>,uint32_t>;
-    explicit constexpr CALLOUT_IPMI_SENSOR_NUM(uint32_t a) : _entry(entry("CALLOUT_IPMI_SENSOR_NUM=%u", a)) {};
+    using type =
+        std::tuple<std::decay_t<decltype("CALLOUT_IPMI_SENSOR_NUM=%u")>,
+                   uint32_t>;
+    explicit constexpr CALLOUT_IPMI_SENSOR_NUM(uint32_t a) :
+        _entry(entry("CALLOUT_IPMI_SENSOR_NUM=%u", a)){};
     type _entry;
 };
 
-}  // namespace _IPMISensor
+} // namespace _IPMISensor
 
 struct IPMISensor
 {
     static constexpr auto L = level::ERR;
     using CALLOUT_IPMI_SENSOR_NUM = _IPMISensor::CALLOUT_IPMI_SENSOR_NUM;
     using metadata_types = std::tuple<CALLOUT_IPMI_SENSOR_NUM>;
-
 };
 
 } // namespace Callout
@@ -3212,17 +3042,17 @@ struct IPMISensor
 } // namespace openbmc_project
 } // namespace xyz
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::xyz::openbmc_project::Common::Callout::Error::IPMISensor>
+struct map_exception_type<
+    sdbusplus::xyz::openbmc_project::Common::Callout::Error::IPMISensor>
 {
     using type = xyz::openbmc_project::Common::Callout::IPMISensor;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -3243,20 +3073,22 @@ struct RAW_STATUS
      * mako template lookups.
      */
     static constexpr auto str_short = "RAW_STATUS";
-    using type = std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>,const char*>;
-    explicit constexpr RAW_STATUS(const char* a) : _entry(entry("RAW_STATUS=%s", a)) {};
+    using type =
+        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
+    explicit constexpr RAW_STATUS(const char* a) :
+        _entry(entry("RAW_STATUS=%s", a)){};
     type _entry;
 };
 
-}  // namespace _PowerSupplyInputFault
+} // namespace _PowerSupplyInputFault
 
 struct PowerSupplyInputFault
 {
     static constexpr auto L = level::ERR;
     using RAW_STATUS = _PowerSupplyInputFault::RAW_STATUS;
-    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::Inventory::CALLOUT_INVENTORY_PATH;
+    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::
+        Inventory::CALLOUT_INVENTORY_PATH;
     using metadata_types = std::tuple<RAW_STATUS, CALLOUT_INVENTORY_PATH>;
-
 };
 
 } // namespace Fault
@@ -3264,17 +3096,17 @@ struct PowerSupplyInputFault
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerSupplyInputFault>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerSupplyInputFault>
 {
     using type = org::open_power::Witherspoon::Fault::PowerSupplyInputFault;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -3295,20 +3127,22 @@ struct RAW_STATUS
      * mako template lookups.
      */
     static constexpr auto str_short = "RAW_STATUS";
-    using type = std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>,const char*>;
-    explicit constexpr RAW_STATUS(const char* a) : _entry(entry("RAW_STATUS=%s", a)) {};
+    using type =
+        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
+    explicit constexpr RAW_STATUS(const char* a) :
+        _entry(entry("RAW_STATUS=%s", a)){};
     type _entry;
 };
 
-}  // namespace _PowerSupplyShouldBeOn
+} // namespace _PowerSupplyShouldBeOn
 
 struct PowerSupplyShouldBeOn
 {
     static constexpr auto L = level::ERR;
     using RAW_STATUS = _PowerSupplyShouldBeOn::RAW_STATUS;
-    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::Inventory::CALLOUT_INVENTORY_PATH;
+    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::
+        Inventory::CALLOUT_INVENTORY_PATH;
     using metadata_types = std::tuple<RAW_STATUS, CALLOUT_INVENTORY_PATH>;
-
 };
 
 } // namespace Fault
@@ -3316,17 +3150,17 @@ struct PowerSupplyShouldBeOn
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerSupplyShouldBeOn>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerSupplyShouldBeOn>
 {
     using type = org::open_power::Witherspoon::Fault::PowerSupplyShouldBeOn;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -3347,20 +3181,22 @@ struct RAW_STATUS
      * mako template lookups.
      */
     static constexpr auto str_short = "RAW_STATUS";
-    using type = std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>,const char*>;
-    explicit constexpr RAW_STATUS(const char* a) : _entry(entry("RAW_STATUS=%s", a)) {};
+    using type =
+        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
+    explicit constexpr RAW_STATUS(const char* a) :
+        _entry(entry("RAW_STATUS=%s", a)){};
     type _entry;
 };
 
-}  // namespace _PowerSupplyOutputOvercurrent
+} // namespace _PowerSupplyOutputOvercurrent
 
 struct PowerSupplyOutputOvercurrent
 {
     static constexpr auto L = level::ERR;
     using RAW_STATUS = _PowerSupplyOutputOvercurrent::RAW_STATUS;
-    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::Inventory::CALLOUT_INVENTORY_PATH;
+    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::
+        Inventory::CALLOUT_INVENTORY_PATH;
     using metadata_types = std::tuple<RAW_STATUS, CALLOUT_INVENTORY_PATH>;
-
 };
 
 } // namespace Fault
@@ -3368,17 +3204,18 @@ struct PowerSupplyOutputOvercurrent
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerSupplyOutputOvercurrent>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerSupplyOutputOvercurrent>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerSupplyOutputOvercurrent;
+    using type =
+        org::open_power::Witherspoon::Fault::PowerSupplyOutputOvercurrent;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -3399,20 +3236,22 @@ struct RAW_STATUS
      * mako template lookups.
      */
     static constexpr auto str_short = "RAW_STATUS";
-    using type = std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>,const char*>;
-    explicit constexpr RAW_STATUS(const char* a) : _entry(entry("RAW_STATUS=%s", a)) {};
+    using type =
+        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
+    explicit constexpr RAW_STATUS(const char* a) :
+        _entry(entry("RAW_STATUS=%s", a)){};
     type _entry;
 };
 
-}  // namespace _PowerSupplyOutputOvervoltage
+} // namespace _PowerSupplyOutputOvervoltage
 
 struct PowerSupplyOutputOvervoltage
 {
     static constexpr auto L = level::ERR;
     using RAW_STATUS = _PowerSupplyOutputOvervoltage::RAW_STATUS;
-    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::Inventory::CALLOUT_INVENTORY_PATH;
+    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::
+        Inventory::CALLOUT_INVENTORY_PATH;
     using metadata_types = std::tuple<RAW_STATUS, CALLOUT_INVENTORY_PATH>;
-
 };
 
 } // namespace Fault
@@ -3420,17 +3259,18 @@ struct PowerSupplyOutputOvervoltage
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerSupplyOutputOvervoltage>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerSupplyOutputOvervoltage>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerSupplyOutputOvervoltage;
+    using type =
+        org::open_power::Witherspoon::Fault::PowerSupplyOutputOvervoltage;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -3451,20 +3291,22 @@ struct RAW_STATUS
      * mako template lookups.
      */
     static constexpr auto str_short = "RAW_STATUS";
-    using type = std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>,const char*>;
-    explicit constexpr RAW_STATUS(const char* a) : _entry(entry("RAW_STATUS=%s", a)) {};
+    using type =
+        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
+    explicit constexpr RAW_STATUS(const char* a) :
+        _entry(entry("RAW_STATUS=%s", a)){};
     type _entry;
 };
 
-}  // namespace _PowerSupplyFanFault
+} // namespace _PowerSupplyFanFault
 
 struct PowerSupplyFanFault
 {
     static constexpr auto L = level::ERR;
     using RAW_STATUS = _PowerSupplyFanFault::RAW_STATUS;
-    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::Inventory::CALLOUT_INVENTORY_PATH;
+    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::
+        Inventory::CALLOUT_INVENTORY_PATH;
     using metadata_types = std::tuple<RAW_STATUS, CALLOUT_INVENTORY_PATH>;
-
 };
 
 } // namespace Fault
@@ -3472,17 +3314,17 @@ struct PowerSupplyFanFault
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerSupplyFanFault>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerSupplyFanFault>
 {
     using type = org::open_power::Witherspoon::Fault::PowerSupplyFanFault;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -3503,20 +3345,22 @@ struct RAW_STATUS
      * mako template lookups.
      */
     static constexpr auto str_short = "RAW_STATUS";
-    using type = std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>,const char*>;
-    explicit constexpr RAW_STATUS(const char* a) : _entry(entry("RAW_STATUS=%s", a)) {};
+    using type =
+        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
+    explicit constexpr RAW_STATUS(const char* a) :
+        _entry(entry("RAW_STATUS=%s", a)){};
     type _entry;
 };
 
-}  // namespace _PowerSupplyTemperatureFault
+} // namespace _PowerSupplyTemperatureFault
 
 struct PowerSupplyTemperatureFault
 {
     static constexpr auto L = level::ERR;
     using RAW_STATUS = _PowerSupplyTemperatureFault::RAW_STATUS;
-    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::Inventory::CALLOUT_INVENTORY_PATH;
+    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::
+        Inventory::CALLOUT_INVENTORY_PATH;
     using metadata_types = std::tuple<RAW_STATUS, CALLOUT_INVENTORY_PATH>;
-
 };
 
 } // namespace Fault
@@ -3524,17 +3368,18 @@ struct PowerSupplyTemperatureFault
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::PowerSupplyTemperatureFault>
+struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::
+                              Error::PowerSupplyTemperatureFault>
 {
-    using type = org::open_power::Witherspoon::Fault::PowerSupplyTemperatureFault;
+    using type =
+        org::open_power::Witherspoon::Fault::PowerSupplyTemperatureFault;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -3555,20 +3400,22 @@ struct RAW_STATUS
      * mako template lookups.
      */
     static constexpr auto str_short = "RAW_STATUS";
-    using type = std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>,const char*>;
-    explicit constexpr RAW_STATUS(const char* a) : _entry(entry("RAW_STATUS=%s", a)) {};
+    using type =
+        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
+    explicit constexpr RAW_STATUS(const char* a) :
+        _entry(entry("RAW_STATUS=%s", a)){};
     type _entry;
 };
 
-}  // namespace _GPUPowerFault
+} // namespace _GPUPowerFault
 
 struct GPUPowerFault
 {
     static constexpr auto L = level::ERR;
     using RAW_STATUS = _GPUPowerFault::RAW_STATUS;
-    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::Inventory::CALLOUT_INVENTORY_PATH;
+    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::
+        Inventory::CALLOUT_INVENTORY_PATH;
     using metadata_types = std::tuple<RAW_STATUS, CALLOUT_INVENTORY_PATH>;
-
 };
 
 } // namespace Fault
@@ -3576,17 +3423,17 @@ struct GPUPowerFault
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::GPUPowerFault>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::GPUPowerFault>
 {
     using type = org::open_power::Witherspoon::Fault::GPUPowerFault;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -3607,20 +3454,22 @@ struct RAW_STATUS
      * mako template lookups.
      */
     static constexpr auto str_short = "RAW_STATUS";
-    using type = std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>,const char*>;
-    explicit constexpr RAW_STATUS(const char* a) : _entry(entry("RAW_STATUS=%s", a)) {};
+    using type =
+        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
+    explicit constexpr RAW_STATUS(const char* a) :
+        _entry(entry("RAW_STATUS=%s", a)){};
     type _entry;
 };
 
-}  // namespace _GPUOverTemp
+} // namespace _GPUOverTemp
 
 struct GPUOverTemp
 {
     static constexpr auto L = level::ERR;
     using RAW_STATUS = _GPUOverTemp::RAW_STATUS;
-    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::Inventory::CALLOUT_INVENTORY_PATH;
+    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::
+        Inventory::CALLOUT_INVENTORY_PATH;
     using metadata_types = std::tuple<RAW_STATUS, CALLOUT_INVENTORY_PATH>;
-
 };
 
 } // namespace Fault
@@ -3628,17 +3477,17 @@ struct GPUOverTemp
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::GPUOverTemp>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::GPUOverTemp>
 {
     using type = org::open_power::Witherspoon::Fault::GPUOverTemp;
 };
 
-}
+} // namespace details
 
 namespace org
 {
@@ -3659,20 +3508,22 @@ struct RAW_STATUS
      * mako template lookups.
      */
     static constexpr auto str_short = "RAW_STATUS";
-    using type = std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>,const char*>;
-    explicit constexpr RAW_STATUS(const char* a) : _entry(entry("RAW_STATUS=%s", a)) {};
+    using type =
+        std::tuple<std::decay_t<decltype("RAW_STATUS=%s")>, const char*>;
+    explicit constexpr RAW_STATUS(const char* a) :
+        _entry(entry("RAW_STATUS=%s", a)){};
     type _entry;
 };
 
-}  // namespace _MemoryPowerFault
+} // namespace _MemoryPowerFault
 
 struct MemoryPowerFault
 {
     static constexpr auto L = level::ERR;
     using RAW_STATUS = _MemoryPowerFault::RAW_STATUS;
-    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::Inventory::CALLOUT_INVENTORY_PATH;
+    using CALLOUT_INVENTORY_PATH = xyz::openbmc_project::Common::Callout::
+        Inventory::CALLOUT_INVENTORY_PATH;
     using metadata_types = std::tuple<RAW_STATUS, CALLOUT_INVENTORY_PATH>;
-
 };
 
 } // namespace Fault
@@ -3680,18 +3531,17 @@ struct MemoryPowerFault
 } // namespace open_power
 } // namespace org
 
-
 namespace details
 {
 
 template <>
-struct map_exception_type<sdbusplus::org::open_power::Witherspoon::Fault::Error::MemoryPowerFault>
+struct map_exception_type<
+    sdbusplus::org::open_power::Witherspoon::Fault::Error::MemoryPowerFault>
 {
     using type = org::open_power::Witherspoon::Fault::MemoryPowerFault;
 };
 
-}
-
+} // namespace details
 
 } // namespace logging
 

--- a/org/open_power/Witherspoon/Fault.errors.yaml
+++ b/org/open_power/Witherspoon/Fault.errors.yaml
@@ -24,122 +24,116 @@
 - name: PowerOnFailure
   description: System power failed to turn on
 
-- name: PowerOnErrorCode0
+- name: ErrorCode0
   description: Read CPLD-register fail
   
-- name: PowerOnErrorCode1
-  description: Power on error reason is PSU1_PGOOD fail
+- name: ErrorCode1
+  description: CPLD's error reason is PSU1_PGOOD fail
 
-- name: PowerOnErrorCode2
-  description: Power on error reason is PSU0_PGOOD fail
+- name: ErrorCode2
+  description: CPLD's error reason is PSU0_PGOOD fail
 
-- name: PowerOnErrorCode3
-  description: Power on error reason is 240Va_Fault_A fail
+- name: ErrorCode3
+  description: CPLD's error reason is 240Va_Fault_A fail
 
-- name: PowerOnErrorCode4
-  description: Power on error reason is 240Va_Fault_B fail
+- name: ErrorCode4
+  description: CPLD's error reason is 240Va_Fault_B fail
 
-- name: PowerOnErrorCode5
-  description: Power on error reason is 240Va_Fault_C fail
+- name: ErrorCode5
+  description: CPLD's error reason is 240Va_Fault_C fail
 
-- name: PowerOnErrorCode6
-  description: Power on error reason is 240Va_Fault_D fail
+- name: ErrorCode6
+  description: CPLD's error reason is 240Va_Fault_D fail
 
-- name: PowerOnErrorCode7
-  description: Power on error reason is 240Va_Fault_E fail
+- name: ErrorCode7
+  description: CPLD's error reason is 240Va_Fault_E fail
 
-- name: PowerOnErrorCode8
-  description: Power on error reason is 240Va_Fault_F fail
+- name: ErrorCode8
+  description: CPLD's error reason is 240Va_Fault_F fail
 
-- name: PowerOnErrorCode9
-  description: Power on error reason is 240Va_Fault_G fail
+- name: ErrorCode9
+  description: CPLD's error reason is 240Va_Fault_G fail
 
-- name: PowerOnErrorCode10
-  description: Power on error reason is 240Va_Fault_H fail
+- name: ErrorCode10
+  description: CPLD's error reason is 240Va_Fault_H fail
 
-- name: PowerOnErrorCode11
-  description: Power on error reason is 240Va_Fault_J fail
+- name: ErrorCode11
+  description: CPLD's error reason is 240Va_Fault_J fail
 
-- name: PowerOnErrorCode12
-  description: Power on error reason is 240Va_Fault_K fail
+- name: ErrorCode12
+  description: CPLD's error reason is 240Va_Fault_K fail
 
-- name: PowerOnErrorCode13
-  description: Power on error reason is 240Va_Fault_L fail
+- name: ErrorCode13
+  description: CPLD's error reason is 240Va_Fault_L fail
 
-- name: PowerOnErrorCode14
-  description: Power on error reason is P5V_pgood fail
+- name: ErrorCode14
+  description: CPLD's error reason is P5V_pgood fail
 
-- name: PowerOnErrorCode15
-  description: Power on error reason is P3V3_pgood fail
+- name: ErrorCode15
+  description: CPLD's error reason is P3V3_pgood fail
 
-- name: PowerOnErrorCode16
-  description: Power on error reason is P1V8_pgood fail
+- name: ErrorCode16
+  description: CPLD's error reason is P1V8_pgood fail
 
-- name: PowerOnErrorCode17
-  description: Power on error reason is P1V1_pgood fail
+- name: ErrorCode17
+  description: CPLD's error reason is P1V1_pgood fail
 
-- name: PowerOnErrorCode18
-  description: Power on error reason is P0V9_pgood fail
+- name: ErrorCode18
+  description: CPLD's error reason is P0V9_pgood fail
 
-- name: PowerOnErrorCode19
-  description: Power on error reason is P2V5A_pgood fail
+- name: ErrorCode19
+  description: CPLD's error reason is P2V5A_pgood fail
 
-- name: PowerOnErrorCode20
-  description: Power on error reason is P2V5B_pgood fail
+- name: ErrorCode20
+  description: CPLD's error reason is P2V5B_pgood fail
 
-- name: PowerOnErrorCode21
-  description: Power on error reason is Vdn0_pgood fail
+- name: ErrorCode21
+  description: CPLD's error reason is Vdn0_pgood fail
 
-- name: PowerOnErrorCode22
-  description: Power on error reason is Vdn1_pgood fail
+- name: ErrorCode22
+  description: CPLD's error reason is Vdn1_pgood fail
 
-- name: PowerOnErrorCode23
-  description: Power on error reason is P1V5_pgood fail
+- name: ErrorCode23
+  description: CPLD's error reason is P1V5_pgood fail
 
-- name: PowerOnErrorCode24
-  description: Power on error reason is Vio0_pgood fail
+- name: ErrorCode24
+  description: CPLD's error reason is Vio0_pgood fail
 
-- name: PowerOnErrorCode25
-  description: Power on error reason is Vio1_pgood fail
+- name: ErrorCode25
+  description: CPLD's error reason is Vio1_pgood fail
 
-- name: PowerOnErrorCode26
-  description: Power on error reason is Vdd0_pgood fail
+- name: ErrorCode26
+  description: CPLD's error reason is Vdd0_pgood fail
 
-- name: PowerOnErrorCode27
-  description: Power on error reason is Vcs0_pgood fail
+- name: ErrorCode27
+  description: CPLD's error reason is Vcs0_pgood fail
 
-- name: PowerOnErrorCode28
-  description: Power on error reason is Vdd1_pgood fail
+- name: ErrorCode28
+  description: CPLD's error reason is Vdd1_pgood fail
 
-- name: PowerOnErrorCode29
-  description: Power on error reason is Vcs1_pgood fail
+- name: ErrorCode29
+  description: CPLD's error reason is Vcs1_pgood fail
 
-- name: PowerOnErrorCode30
-  description: Power on error reason is Vddr0_pgood fail
+- name: ErrorCode30
+  description: CPLD's error reason is Vddr0_pgood fail
 
-- name: PowerOnErrorCode31
-  description: Power on error reason is Vtt0_pgood fail
+- name: ErrorCode31
+  description: CPLD's error reason is Vtt0_pgood fail
 
-- name: PowerOnErrorCode32
-  description: Power on error reason is Vddr1_pgood fail
+- name: ErrorCode32
+  description: CPLD's error reason is Vddr1_pgood fail
 
-- name: PowerOnErrorCode33
-  description: Power on error reason is Vtt1_pgood fail
+- name: ErrorCode33
+  description: CPLD's error reason is Vtt1_pgood fail
 
-- name: PowerOnErrorCode34
-  description: Power on error reason is GPU0_pgood fail
+- name: ErrorCode34
+  description: CPLD's error reason is GPU0_pgood fail
 
-- name: PowerOnErrorCode35
-  description: Power on error reason is GPU1_pgood fail
+- name: ErrorCode35
+  description: CPLD's error reason is GPU1_pgood fail
 
-- name: PowerOnErrorCode36
-  description: Power on error reason is PSU0&PSU1_pgood fail
-
-- name: PsuErrorCode0
-  description: PSU1 power fail
-
-- name: PsuErrorCode1
-  description: PSU0 power fail
+- name: ErrorCode36
+  description: CPLD's error reason is PSU0&PSU1_pgood fail
 
 - name: PowerSequencerVoltageFault
   description: The power sequencer chip detected a voltage fault

--- a/org/open_power/Witherspoon/Fault.metadata.yaml
+++ b/org/open_power/Witherspoon/Fault.metadata.yaml
@@ -52,121 +52,115 @@
 - name: PowerOnFailure
   level: ERR
 
-- name: PowerOnErrorCode1
+- name: ErrorCode0
   level: ERR
 
-- name: PowerOnErrorCode2
+- name: ErrorCode1
   level: ERR
 
-- name: PowerOnErrorCode3
+- name: ErrorCode2
   level: ERR
 
-- name: PowerOnErrorCode4
+- name: ErrorCode3
   level: ERR
 
-- name: PowerOnErrorCode5
+- name: ErrorCode4
   level: ERR
 
-- name: PowerOnErrorCode6
+- name: ErrorCode5
   level: ERR
 
-- name: PowerOnErrorCode7
+- name: ErrorCode6
   level: ERR
 
-- name: PowerOnErrorCode8
+- name: ErrorCode7
   level: ERR
 
-- name: PowerOnErrorCode9
+- name: ErrorCode8
   level: ERR
 
-- name: PowerOnErrorCode10
+- name: ErrorCode9
   level: ERR
 
-- name: PowerOnErrorCode11
+- name: ErrorCode10
   level: ERR
 
-- name: PowerOnErrorCode12
+- name: ErrorCode11
   level: ERR
 
-- name: PowerOnErrorCode13
+- name: ErrorCode12
   level: ERR
 
-- name: PowerOnErrorCode14
+- name: ErrorCode13
   level: ERR
 
-- name: PowerOnErrorCode15
+- name: ErrorCode14
   level: ERR
 
-- name: PowerOnErrorCode16
+- name: ErrorCode15
   level: ERR
 
-- name: PowerOnErrorCode17
+- name: ErrorCode16
   level: ERR
 
-- name: PowerOnErrorCode18
+- name: ErrorCode17
   level: ERR
 
-- name: PowerOnErrorCode19
+- name: ErrorCode18
   level: ERR
 
-- name: PowerOnErrorCode20
+- name: ErrorCode19
   level: ERR
 
-- name: PowerOnErrorCode21
+- name: ErrorCode20
   level: ERR
 
-- name: PowerOnErrorCode22
+- name: ErrorCode21
   level: ERR
 
-- name: PowerOnErrorCode23
+- name: ErrorCode22
   level: ERR
 
-- name: PowerOnErrorCode24
+- name: ErrorCode23
   level: ERR
 
-- name: PowerOnErrorCode25
+- name: ErrorCode24
   level: ERR
 
-- name: PowerOnErrorCode26
+- name: ErrorCode25
   level: ERR
 
-- name: PowerOnErrorCode27
+- name: ErrorCode26
   level: ERR
 
-- name: PowerOnErrorCode28
+- name: ErrorCode27
   level: ERR
 
-- name: PowerOnErrorCode29
+- name: ErrorCode28
   level: ERR
 
-- name: PowerOnErrorCode30
+- name: ErrorCode29
   level: ERR
 
-- name: PowerOnErrorCode31
+- name: ErrorCode30
   level: ERR
 
-- name: PowerOnErrorCode32
+- name: ErrorCode31
   level: ERR
 
-- name: PowerOnErrorCode33
+- name: ErrorCode32
   level: ERR
 
-- name: PowerOnErrorCode34
+- name: ErrorCode33
   level: ERR
 
-- name: PowerOnErrorCode35
+- name: ErrorCode34
   level: ERR
 
-- name: PowerOnErrorCode36
+- name: ErrorCode35
   level: ERR
 
-- name: PowerOnErrorCode0
-  level: ERR
-
-- name: PsuErrorCode0
-  level: ERR
-
-- name: PsuErrorCode1
+- name: ErrorCode36
   level: ERR
 
 - name: PowerSequencerVoltageFault

--- a/power-sequencer/mihawk-cpld.cpp
+++ b/power-sequencer/mihawk-cpld.cpp
@@ -2,6 +2,7 @@
 
 #include "mihawk-cpld.hpp"
 
+#include "gpio.hpp"
 #include "utility.hpp"
 
 #include <errno.h>
@@ -36,8 +37,8 @@ const static constexpr size_t StatusReg_1 = 0x20;
 // SMLink Status Register(Power-on error code Register)
 const static constexpr size_t StatusReg_2 = 0x21;
 
-// SMLink Status Register(PSU register code Register)
-const static constexpr size_t StatusReg_3 = 0x05;
+// SMLink Status Register(Power-ready error code Register)
+const static constexpr size_t StatusReg_3 = 0x22;
 
 using namespace std;
 namespace witherspoon
@@ -61,159 +62,130 @@ void MIHAWKCPLD::onFailure()
     bool poweronError = checkPoweronFault();
 
     // If the interrupt of power_on_error is switch on,
-    // read CPLD_register error code to analyze and report the error event.
+    // read CPLD_register error code to analyze
+    // and report the error log event.
     if (poweronError)
     {
-        std::cerr << "CPLD : Power_ON error! \n";
-        int errorcode;
-        errorcode = readFromCPLDPSUErrorCode(busId, slaveAddr);
-        if (errorcode == powerOnErrorCode_0)
+        ErrorCode code;
+        code = static_cast<ErrorCode>(readFromCPLDErrorCode(StatusReg_2));
+
+        switch (code)
         {
-            report<PowerOnErrorCode0>();
-        }
-        else if (errorcode == powerOnErrorCode_1)
-        {
-            report<PowerOnErrorCode1>();
-        }
-        else if (errorcode == powerOnErrorCode_2)
-        {
-            report<PowerOnErrorCode2>();
-        }
-        else if (errorcode == powerOnErrorCode_3)
-        {
-            report<PowerOnErrorCode3>();
-        }
-        else if (errorcode == powerOnErrorCode_4)
-        {
-            report<PowerOnErrorCode4>();
-        }
-        else if (errorcode == powerOnErrorCode_5)
-        {
-            report<PowerOnErrorCode5>();
-        }
-        else if (errorcode == powerOnErrorCode_6)
-        {
-            report<PowerOnErrorCode6>();
-        }
-        else if (errorcode == powerOnErrorCode_7)
-        {
-            report<PowerOnErrorCode7>();
-        }
-        else if (errorcode == powerOnErrorCode_8)
-        {
-            report<PowerOnErrorCode8>();
-        }
-        else if (errorcode == powerOnErrorCode_9)
-        {
-            report<PowerOnErrorCode9>();
-        }
-        else if (errorcode == powerOnErrorCode_10)
-        {
-            report<PowerOnErrorCode10>();
-        }
-        else if (errorcode == powerOnErrorCode_11)
-        {
-            report<PowerOnErrorCode11>();
-        }
-        else if (errorcode == powerOnErrorCode_12)
-        {
-            report<PowerOnErrorCode12>();
-        }
-        else if (errorcode == powerOnErrorCode_13)
-        {
-            report<PowerOnErrorCode13>();
-        }
-        else if (errorcode == powerOnErrorCode_14)
-        {
-            report<PowerOnErrorCode14>();
-        }
-        else if (errorcode == powerOnErrorCode_15)
-        {
-            report<PowerOnErrorCode15>();
-        }
-        else if (errorcode == powerOnErrorCode_16)
-        {
-            report<PowerOnErrorCode16>();
-        }
-        else if (errorcode == powerOnErrorCode_17)
-        {
-            report<PowerOnErrorCode17>();
-        }
-        else if (errorcode == powerOnErrorCode_18)
-        {
-            report<PowerOnErrorCode18>();
-        }
-        else if (errorcode == powerOnErrorCode_19)
-        {
-            report<PowerOnErrorCode19>();
-        }
-        else if (errorcode == powerOnErrorCode_20)
-        {
-            report<PowerOnErrorCode20>();
-        }
-        else if (errorcode == powerOnErrorCode_21)
-        {
-            report<PowerOnErrorCode21>();
-        }
-        else if (errorcode == powerOnErrorCode_22)
-        {
-            report<PowerOnErrorCode22>();
-        }
-        else if (errorcode == powerOnErrorCode_23)
-        {
-            report<PowerOnErrorCode23>();
-        }
-        else if (errorcode == powerOnErrorCode_24)
-        {
-            report<PowerOnErrorCode24>();
-        }
-        else if (errorcode == powerOnErrorCode_25)
-        {
-            report<PowerOnErrorCode25>();
-        }
-        else if (errorcode == powerOnErrorCode_26)
-        {
-            report<PowerOnErrorCode26>();
-        }
-        else if (errorcode == powerOnErrorCode_27)
-        {
-            report<PowerOnErrorCode27>();
-        }
-        else if (errorcode == powerOnErrorCode_28)
-        {
-            report<PowerOnErrorCode28>();
-        }
-        else if (errorcode == powerOnErrorCode_29)
-        {
-            report<PowerOnErrorCode29>();
-        }
-        else if (errorcode == powerOnErrorCode_30)
-        {
-            report<PowerOnErrorCode30>();
-        }
-        else if (errorcode == powerOnErrorCode_31)
-        {
-            report<PowerOnErrorCode31>();
-        }
-        else if (errorcode == powerOnErrorCode_32)
-        {
-            report<PowerOnErrorCode32>();
-        }
-        else if (errorcode == powerOnErrorCode_33)
-        {
-            report<PowerOnErrorCode33>();
-        }
-        else if (errorcode == powerOnErrorCode_34)
-        {
-            report<PowerOnErrorCode34>();
-        }
-        else if (errorcode == powerOnErrorCode_35)
-        {
-            report<PowerOnErrorCode35>();
-        }
-        else if (errorcode == powerOnErrorCode_36)
-        {
-            report<PowerOnErrorCode36>();
+            case ErrorCode::_1:
+                report<ErrorCode1>();
+                break;
+            case ErrorCode::_2:
+                report<ErrorCode2>();
+                break;
+            case ErrorCode::_3:
+                report<ErrorCode3>();
+                break;
+            case ErrorCode::_4:
+                report<ErrorCode4>();
+                break;
+            case ErrorCode::_5:
+                report<ErrorCode5>();
+                break;
+            case ErrorCode::_6:
+                report<ErrorCode6>();
+                break;
+            case ErrorCode::_7:
+                report<ErrorCode7>();
+                break;
+            case ErrorCode::_8:
+                report<ErrorCode8>();
+                break;
+            case ErrorCode::_9:
+                report<ErrorCode9>();
+                break;
+            case ErrorCode::_10:
+                report<ErrorCode10>();
+                break;
+            case ErrorCode::_11:
+                report<ErrorCode11>();
+                break;
+            case ErrorCode::_12:
+                report<ErrorCode12>();
+                break;
+            case ErrorCode::_13:
+                report<ErrorCode13>();
+                break;
+            case ErrorCode::_14:
+                report<ErrorCode14>();
+                break;
+            case ErrorCode::_15:
+                report<ErrorCode15>();
+                break;
+            case ErrorCode::_16:
+                report<ErrorCode16>();
+                break;
+            case ErrorCode::_17:
+                report<ErrorCode17>();
+                break;
+            case ErrorCode::_18:
+                report<ErrorCode18>();
+                break;
+            case ErrorCode::_19:
+                report<ErrorCode19>();
+                break;
+            case ErrorCode::_20:
+                report<ErrorCode20>();
+                break;
+            case ErrorCode::_21:
+                report<ErrorCode21>();
+                break;
+            case ErrorCode::_22:
+                report<ErrorCode22>();
+                break;
+            case ErrorCode::_23:
+                report<ErrorCode23>();
+                break;
+            case ErrorCode::_24:
+                report<ErrorCode24>();
+                break;
+            case ErrorCode::_25:
+                report<ErrorCode25>();
+                break;
+            case ErrorCode::_26:
+                report<ErrorCode26>();
+                break;
+            case ErrorCode::_27:
+                report<ErrorCode27>();
+                break;
+            case ErrorCode::_28:
+                report<ErrorCode28>();
+                break;
+            case ErrorCode::_29:
+                report<ErrorCode29>();
+                break;
+            case ErrorCode::_30:
+                report<ErrorCode30>();
+                break;
+            case ErrorCode::_31:
+                report<ErrorCode31>();
+                break;
+            case ErrorCode::_32:
+                report<ErrorCode32>();
+                break;
+            case ErrorCode::_33:
+                report<ErrorCode33>();
+                break;
+            case ErrorCode::_34:
+                report<ErrorCode34>();
+                break;
+            case ErrorCode::_35:
+                report<ErrorCode35>();
+                break;
+            case ErrorCode::_36:
+                report<ErrorCode36>();
+                break;
+            default:
+                // If the errorcode isn't 1~36,
+                // it indicates that the CPLD register
+                // has a reading issue,
+                // so the errorcode0 error is reported.
+                report<ErrorCode0>();
+                break;
         }
         clearCPLDregister();
     }
@@ -221,20 +193,197 @@ void MIHAWKCPLD::onFailure()
 
 void MIHAWKCPLD::analyze()
 {
-    //analyze psu status when power_on fault.
-    auto poweronError = checkPoweronFault();
-    if(poweronError)
+    bool powerreadyError = checkPowerreadyFault();
+
+    // Use the function of GPIO class to check
+    // GPIOF0(CPLD uses).
+    using namespace witherspoon::gpio;
+    GPIO gpio{"/dev/gpiochip0", static_cast<gpioNum_t>(40), Direction::input};
+
+    // Check GPIOFO pin whether is switched off.
+    // if GPIOF0 has been switched off,
+    // check CPLD's errorcode & report error.
+    if (gpio.read() == Value::low)
     {
-        int errorcode;
-        errorcode = checkPSUDCpgood();
-        if (!((errorcode >> 1) & 1) && !((errorcode >> 3) & 1) )
+        // If the interrupt of power_ready_error is switch on,
+        // read CPLD_register error code to analyze and
+        // report the error event.
+        if (powerreadyError)
         {
-            report<PsuErrorCode0>();
+            ErrorCode code;
+            code = static_cast<ErrorCode>(readFromCPLDErrorCode(StatusReg_3));
+
+            if (!errorcodeMask)
+            {
+                // Check the errorcodeMask & errorcode whether
+                // are the same value to avoid to report the
+                // same error again.
+                switch (code)
+                {
+                    case ErrorCode::_1:
+                        report<ErrorCode1>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_2:
+                        report<ErrorCode2>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_3:
+                        report<ErrorCode3>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_4:
+                        report<ErrorCode4>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_5:
+                        report<ErrorCode5>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_6:
+                        report<ErrorCode6>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_7:
+                        report<ErrorCode7>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_8:
+                        report<ErrorCode8>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_9:
+                        report<ErrorCode9>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_10:
+                        report<ErrorCode10>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_11:
+                        report<ErrorCode11>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_12:
+                        report<ErrorCode12>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_13:
+                        report<ErrorCode13>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_14:
+                        report<ErrorCode14>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_15:
+                        report<ErrorCode15>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_16:
+                        report<ErrorCode16>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_17:
+                        report<ErrorCode17>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_18:
+                        report<ErrorCode18>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_19:
+                        report<ErrorCode19>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_20:
+                        report<ErrorCode20>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_21:
+                        report<ErrorCode21>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_22:
+                        report<ErrorCode22>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_23:
+                        report<ErrorCode23>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_24:
+                        report<ErrorCode24>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_25:
+                        report<ErrorCode25>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_26:
+                        report<ErrorCode26>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_27:
+                        report<ErrorCode27>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_28:
+                        report<ErrorCode28>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_29:
+                        report<ErrorCode29>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_30:
+                        report<ErrorCode30>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_31:
+                        report<ErrorCode31>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_32:
+                        report<ErrorCode32>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_33:
+                        report<ErrorCode33>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_34:
+                        report<ErrorCode34>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_35:
+                        report<ErrorCode35>();
+                        errorcodeMask = 1;
+                        break;
+                    case ErrorCode::_36:
+                        report<ErrorCode36>();
+                        errorcodeMask = 1;
+                        break;
+                    default:
+                        // If the errorcode is not 1~36,
+                        // it indicates that the CPLD register
+                        // has a reading issue, so the
+                        // errorcode0 error is reported.
+                        report<ErrorCode0>();
+                        errorcodeMask = 1;
+                        break;
+                }
+                clearCPLDregister();
+            }
         }
-        else if (!((errorcode >> 2) & 1) && !((errorcode >> 4) & 1))
-        {
-            report<PsuErrorCode1>();
-        }
+    }
+
+    if (gpio.read() == Value::high)
+    {
+        // If there isn't an error(GPIOF0
+        // which CPLD uses is switched on),
+        // we clear errorcodeMask.
+        errorcodeMask = 0;
     }
 }
 
@@ -274,7 +423,7 @@ bool MIHAWKCPLD::checkPoweronFault()
     }
 
     int statusValue_1;
-    
+
     statusValue_1 = i2c_smbus_read_byte_data(fd, StatusReg_1);
     close(fd);
 
@@ -299,9 +448,9 @@ bool MIHAWKCPLD::checkPoweronFault()
 }
 
 // Read CPLD_register error code and return the result to analyze.
-int MIHAWKCPLD::readFromCPLDPSUErrorCode(int bus, int Addr)
+int MIHAWKCPLD::readFromCPLDErrorCode(int statusReg)
 {
-    std::string i2cBus = "/dev/i2c-" + std::to_string(bus);
+    std::string i2cBus = "/dev/i2c-" + std::to_string(busId);
 
     // open i2c device(CPLD-PSU-register table)
     int fd = open(i2cBus.c_str(), O_RDWR | O_CLOEXEC);
@@ -311,7 +460,7 @@ int MIHAWKCPLD::readFromCPLDPSUErrorCode(int bus, int Addr)
     }
 
     // set i2c slave address
-    if (ioctl(fd, I2C_SLAVE_FORCE, Addr) < 0)
+    if (ioctl(fd, I2C_SLAVE_FORCE, slaveAddr) < 0)
     {
         std::cerr << "Unable to set device address \n";
         close(fd);
@@ -333,7 +482,7 @@ int MIHAWKCPLD::readFromCPLDPSUErrorCode(int bus, int Addr)
     }
 
     int statusValue_2;
-    statusValue_2 = i2c_smbus_read_byte_data(fd, StatusReg_2);
+    statusValue_2 = i2c_smbus_read_byte_data(fd, statusReg);
     close(fd);
 
     if (statusValue_2 < 0)
@@ -346,8 +495,9 @@ int MIHAWKCPLD::readFromCPLDPSUErrorCode(int bus, int Addr)
 }
 
 // Check PSU_DC_PGOOD state form PSU register via CPLD
-int MIHAWKCPLD::checkPSUDCpgood()
+bool MIHAWKCPLD::checkPowerreadyFault()
 {
+    bool result;
     std::string i2cBus = "/dev/i2c-" + std::to_string(busId);
 
     // open i2c device(CPLD-PSU-register table)
@@ -380,11 +530,28 @@ int MIHAWKCPLD::checkPSUDCpgood()
     }
 
     int statusValue_3;
-    statusValue_3 = i2c_smbus_read_byte_data(fd, StatusReg_3);
+    statusValue_3 = i2c_smbus_read_byte_data(fd, StatusReg_1);
     close(fd);
 
+    if (statusValue_3 < 0)
+    {
+        std::cerr << "i2c_smbus_read_byte_data failed \n";
+        result = 0;
+    }
+
+    if ((statusValue_3 >> 6) & 1)
+    {
+        // If power_ready-interrupt-bit is read as 1,
+        // switch on the flag.
+        result = 1;
+    }
+    else
+    {
+        result = 0;
+    }
+
     // return the i2c-read data
-    return statusValue_3;
+    return result;
 }
 
 // Clear CPLD_register after reading.

--- a/power-sequencer/mihawk-cpld.hpp
+++ b/power-sequencer/mihawk-cpld.hpp
@@ -58,19 +58,22 @@ class MIHAWKCPLD : public Device
 
   private:
     /**
-     * If checkPoweronFault() returns "true",
-     * use ReadFromCPLDPSUErrorCode() to read CPLD-error-code-register
+     * If checkPoweronFault() or checkPowerreadyFault()
+     * returns "true", use readFromCPLDErrorCode()
+     * to read CPLD-error-code-register
      * to analyze the fail reason.
      *
-     * @param[in] bus - I2C's bus, ex.i2c-11.
-     * Mihawk's CPLD-register is on i2c-11.
-     *
-     * @param[in] Addr - the i2c-11 address of Mihawk's CPLD-register.
+     * @param[in] statusReg - I2C's statusReg, slaveAddr
+     * offset.
+     * ex.Mihawk's CPLD-register is on slaveAddr ox40 of
+     * i2c-11, but poweron_errcode-register is on slaveAddr
+     * offset 0x21, power_ready-errorcode-register is on
+     * slaveAddr offset 0x22.
      *
      * @return int - the error-code value which is read on
      * CPLD-error-code-register.
      */
-    int readFromCPLDPSUErrorCode(int bus, int Addr);
+    int readFromCPLDErrorCode(int statusReg);
 
     /**
      * Checks for PoweronFault on Mihawk's
@@ -87,9 +90,13 @@ class MIHAWKCPLD : public Device
     void clearCPLDregister();
 
     /**
-     * Check PSU power status via runtime-monitor after power_on_fault.
+     * Check for PowerreadyFault on Mihawk's
+     * CPLD-power_ready-error-interrupt-bit-register
+     * whether is transfered to "1".
+     *
+     * @return bool - true if power_ready fail.
      */
-    int checkPSUDCpgood();
+    bool checkPowerreadyFault();
 
     /**
      * The D-Bus bus object
@@ -97,230 +104,239 @@ class MIHAWKCPLD : public Device
     sdbusplus::bus::bus& bus;
 
     /**
-     * All of powerOnErrorcode are the definition of error-code
-     * which are read on CPLD-error-code-register. 
+     * The parameter which is checked CPLD's the same error
+     * whether is created again.
      */
-    /**
-     * The definition of error-code:
-     *  
-     */
-    const int powerOnErrorCode_0 = 0;
+    bool errorcodeMask;
 
-    /**
-     * The definition of error-code:
-     * PSU1_PGOOD fail.
-     */
-    const int powerOnErrorCode_1 = 1;
+    enum class ErrorCode : int
+    {
+        /**
+         * All of powerOnErrorcode are the definition of error-code
+         * which are read on CPLD-error-code-register.
+         */
+        /**
+         * The definition of error-code:
+         * Read CPLD-error-code-register fail.
+         */
+        _0 = 0,
 
-    /**
-     * The definition of error-code:
-     * PSU0_PGOOD fail.
-     */
-    const int powerOnErrorCode_2 = 2;
+        /**
+         * The definition of error-code:
+         * PSU1_PGOOD fail.
+         */
+        _1 = 1,
 
-    /**
-     * The definition of error-code:
-     * 240Va_Fault_A fail.
-     */
-    const int powerOnErrorCode_3 = 3;
+        /**
+         * The definition of error-code:
+         * PSU0_PGOOD fail.
+         */
+        _2 = 2,
 
-    /**
-     * The definition of error-code:
-     * 240Va_Fault_B fail.
-     */
-    const int powerOnErrorCode_4 = 4;
+        /**
+         * The definition of error-code:
+         * 240Va_Fault_A fail.
+         */
+        _3 = 3,
 
-    /**
-     * The definition of error-code:
-     * 240Va_Fault_C fail.
-     */
-    const int powerOnErrorCode_5 = 5;
+        /**
+         * The definition of error-code:
+         * 240Va_Fault_B fail.
+         */
+        _4 = 4,
 
-    /**
-     * The definition of error-code:
-     * 240Va_Fault_D fail.
-     */
-    const int powerOnErrorCode_6 = 6;
+        /**
+         * The definition of error-code:
+         * 240Va_Fault_C fail.
+         */
+        _5 = 5,
 
-    /**
-     * The definition of error-code:
-     * 240Va_Fault_E fail.
-     */
-    const int powerOnErrorCode_7 = 7;
+        /**
+         * The definition of error-code:
+         * 240Va_Fault_D fail.
+         */
+        _6 = 6,
 
-    /**
-     * The definition of error-code:
-     * 240Va_Fault_F fail.
-     */
-    const int powerOnErrorCode_8 = 8;
+        /**
+         * The definition of error-code:
+         * 240Va_Fault_E fail.
+         */
+        _7 = 7,
 
-    /**
-     * The definition of error-code:
-     * 240Va_Fault_G fail.
-     */
-    const int powerOnErrorCode_9 = 9;
+        /**
+         * The definition of error-code:
+         * 240Va_Fault_F fail.
+         */
+        _8 = 8,
 
-    /**
-     * The definition of error-code:
-     * 240Va_Fault_H fail.
-     */
-    const int powerOnErrorCode_10 = 10;
+        /**
+         * The definition of error-code:
+         * 240Va_Fault_G fail.
+         */
+        _9 = 9,
 
-    /**
-     * The definition of error-code:
-     * 240Va_Fault_J fail.
-     */
-    const int powerOnErrorCode_11 = 11;
+        /**
+         * The definition of error-code:
+         * 240Va_Fault_H fail.
+         */
+        _10 = 10,
 
-    /**
-     * The definition of error-code:
-     * 240Va_Fault_K fail.
-     */
-    const int powerOnErrorCode_12 = 12;
+        /**
+         * The definition of error-code:
+         * 240Va_Fault_J fail.
+         */
+        _11 = 11,
 
-    /**
-     * The definition of error-code:
-     * 240Va_Fault_L fail.
-     */
-    const int powerOnErrorCode_13 = 13;
+        /**
+         * The definition of error-code:
+         * 240Va_Fault_K fail.
+         */
+        _12 = 12,
 
-    /**
-     * The definition of error-code:
-     * P5V_PGOOD fail.
-     */
-    const int powerOnErrorCode_14 = 14;
+        /**
+         * The definition of error-code:
+         * 240Va_Fault_L fail.
+         */
+        _13 = 13,
 
-    /**
-     * The definition of error-code:
-     * P3V3_PGOOD fail.
-     */
-    const int powerOnErrorCode_15 = 15;
+        /**
+         * The definition of error-code:
+         * P5V_PGOOD fail.
+         */
+        _14 = 14,
 
-    /**
-     * The definition of error-code:
-     * P1V8_PGOOD fail.
-     */
-    const int powerOnErrorCode_16 = 16;
+        /**
+         * The definition of error-code:
+         * P3V3_PGOOD fail.
+         */
+        _15 = 15,
 
-    /**
-     * The definition of error-code:
-     * P1V1_PGOOD fail.
-     */
-    const int powerOnErrorCode_17 = 17;
+        /**
+         * The definition of error-code:
+         * P1V8_PGOOD fail.
+         */
+        _16 = 16,
 
-    /**
-     * The definition of error-code:
-     * P0V9_PGOOD fail.
-     */
-    const int powerOnErrorCode_18 = 18;
+        /**
+         * The definition of error-code:
+         * P1V1_PGOOD fail.
+         */
+        _17 = 17,
 
-    /**
-     * The definition of error-code:
-     * P2V5A_PGOOD fail.
-     */
-    const int powerOnErrorCode_19 = 19;
+        /**
+         * The definition of error-code:
+         * P0V9_PGOOD fail.
+         */
+        _18 = 18,
 
-    /**
-     * The definition of error-code:
-     * P2V5B_PGOOD fail.
-     */
-    const int powerOnErrorCode_20 = 20;
+        /**
+         * The definition of error-code:
+         * P2V5A_PGOOD fail.
+         */
+        _19 = 19,
 
-    /**
-     * The definition of error-code:
-     * Vdn0_PGOOD fail.
-     */
-    const int powerOnErrorCode_21 = 21;
+        /**
+         * The definition of error-code:
+         * P2V5B_PGOOD fail.
+         */
+        _20 = 20,
 
-    /**
-     * The definition of error-code:
-     * Vdn1_PGOOD fail.
-     */
-    const int powerOnErrorCode_22 = 22;
+        /**
+         * The definition of error-code:
+         * Vdn0_PGOOD fail.
+         */
+        _21 = 21,
 
-    /**
-     * The definition of error-code:
-     * P1V5_PGOOD fail.
-     */
-    const int powerOnErrorCode_23 = 23;
+        /**
+         * The definition of error-code:
+         * Vdn1_PGOOD fail.
+         */
+        _22 = 22,
 
-    /**
-     * The definition of error-code:
-     * Vio0_PGOOD fail.
-     */
-    const int powerOnErrorCode_24 = 24;
+        /**
+         * The definition of error-code:
+         * P1V5_PGOOD fail.
+         */
+        _23 = 23,
 
-    /**
-     * The definition of error-code:
-     * Vio1_PGOOD fail.
-     */
-    const int powerOnErrorCode_25 = 25;
+        /**
+         * The definition of error-code:
+         * Vio0_PGOOD fail.
+         */
+        _24 = 24,
 
-    /**
-     * The definition of error-code:
-     * Vdd0_PGOOD fail.
-     */
-    const int powerOnErrorCode_26 = 26;
+        /**
+         * The definition of error-code:
+         * Vio1_PGOOD fail.
+         */
+        _25 = 25,
 
-    /**
-     * The definition of error-code:
-     * Vcs0_PGOOD fail.
-     */
-    const int powerOnErrorCode_27 = 27;
+        /**
+         * The definition of error-code:
+         * Vdd0_PGOOD fail.
+         */
+        _26 = 26,
 
-    /**
-     * The definition of error-code:
-     * Vdd1_PGOOD fail.
-     */
-    const int powerOnErrorCode_28 = 28;
+        /**
+         * The definition of error-code:
+         * Vcs0_PGOOD fail.
+         */
+        _27 = 27,
 
-    /**
-     * The definition of error-code:
-     * Vcs1_PGOOD fail.
-     */
-    const int powerOnErrorCode_29 = 29;
+        /**
+         * The definition of error-code:
+         * Vdd1_PGOOD fail.
+         */
+        _28 = 28,
 
-    /**
-     * The definition of error-code:
-     * Vddr0_PGOOD fail.
-     */
-    const int powerOnErrorCode_30 = 30;
+        /**
+         * The definition of error-code:
+         * Vcs1_PGOOD fail.
+         */
+        _29 = 29,
 
-    /**
-     * The definition of error-code:
-     * Vtt0_PGOOD fail.
-     */
-    const int powerOnErrorCode_31 = 31;
+        /**
+         * The definition of error-code:
+         * Vddr0_PGOOD fail.
+         */
+        _30 = 30,
 
-    /**
-     * The definition of error-code:
-     * Vddr1_PGOOD fail.
-     */
-    const int powerOnErrorCode_32 = 32;
+        /**
+         * The definition of error-code:
+         * Vtt0_PGOOD fail.
+         */
+        _31 = 31,
 
-    /**
-     * The definition of error-code:
-     * Vtt1_PGOOD fail.
-     */
-    const int powerOnErrorCode_33 = 33;
+        /**
+         * The definition of error-code:
+         * Vddr1_PGOOD fail.
+         */
+        _32 = 32,
 
-    /**
-     * The definition of error-code:
-     * GPU0_PGOOD fail.
-     */
-    const int powerOnErrorCode_34 = 34;
+        /**
+         * The definition of error-code:
+         * Vtt1_PGOOD fail.
+         */
+        _33 = 33,
 
-    /**
-     * The definition of error-code:
-     * GPU1_PGOOD fail.
-     */
-    const int powerOnErrorCode_35 = 35;
+        /**
+         * The definition of error-code:
+         * GPU0_PGOOD fail.
+         */
+        _34 = 34,
 
-    /**
-     * The definition of error-code:
-     * PSU0PSU1_PGOOD fail.
-     */
-    const int powerOnErrorCode_36 = 170;
+        /**
+         * The definition of error-code:
+         * GPU1_PGOOD fail.
+         */
+        _35 = 35,
+
+        /**
+         * The definition of error-code:
+         * PSU0PSU1_PGOOD fail.
+         */
+        _36 = 170
+    };
 };
 
 } // namespace power


### PR DESCRIPTION
1. Remove the original mihawk runtime-monitor of mihawk-cpld.cpp 
and add the new one to fix mihawk power-sequencer issue.
2. Update mihawk's CPLD errorcode base on the version of phosphor-power.
https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-power/+/25661

Signed-off-by: Andy YF Wang <Andy_YF_Wang@wistron.com> 