### PR TITLE
Modify HDD-fault-monitor detection mechanism

### DIFF
--- a/power-sequencer/mihawk-cpld.hpp
+++ b/power-sequencer/mihawk-cpld.hpp
@@ -375,6 +375,12 @@ class MIHAWKCPLD : public Device
     {
         /**
          * The definition of CPLD-HDD-Fault-code:
+         * no HDD-fault.
+         */
+        _noFault = 0,
+
+        /**
+         * The definition of CPLD-HDD-Fault-code:
          * HDD_0 fail.
          */
         _0 = 1,


### PR DESCRIPTION
Add a new condition that no error is detected and a new condition
that determines that both HDD-faults exist.

Signed-off-by: Andy YF Wang <Andy_YF_Wang@wistron.com>