### PR TITLE
Add the re-checking mechanism for HDD detection

### DIFF
--- a/power-sequencer/mihawk-cpld.hpp
+++ b/power-sequencer/mihawk-cpld.hpp
@@ -117,6 +117,11 @@ class MIHAWKCPLD : public Device
      */
     bool rebuildcodeMask = false;
 
+    /**
+     * The parameter for rechecking HDDError counts.
+     */
+    int recheck = 0;
+
     enum class ErrorCode : int
     {
         /**
@@ -389,7 +394,13 @@ class MIHAWKCPLD : public Device
          * The definition of CPLD-HDD-Fault-code:
          * HDD_1 fail.
          */
-        _1 = 2
+        _1 = 2,
+
+        /**
+         * The definition of CPLD-HDD-Fault-code:
+         * all HDD-fault.
+         */
+        _allFault = 3
     };
 
     /**


### PR DESCRIPTION
Due to the HW limitation, need to add the re-checking mechanism and
the delay mechanism for mowgli's HDD status detection.

Signed-off-by: Andy YF Wang <Andy_YF_Wang@wistron.com>